### PR TITLE
feat: add 404 page with home link

### DIFF
--- a/frontend/admin/src/app/pages/not-found/not-found.component.html
+++ b/frontend/admin/src/app/pages/not-found/not-found.component.html
@@ -1,0 +1,4 @@
+<div class="card">
+  <h1>404 - Page not found</h1>
+  <a routerLink="/">Return home</a>
+</div>


### PR DESCRIPTION
## Summary
- display 404 not found page inside a card
- add link back to the home route

## Testing
- `cd frontend/admin && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76366513883218cb71c73e0bfac75