### PR TITLE
feat: add standalone settings page

### DIFF
--- a/frontend/admin/src/app/pages/settings/settings.component.html
+++ b/frontend/admin/src/app/pages/settings/settings.component.html
@@ -1,0 +1,509 @@
+<div class="space-y-6">
+  <div>
+    <h1 class="text-3xl font-bold settings-title" data-testid="text-settings-title">
+      Settings
+    </h1>
+    <p class="settings-hint mt-1" data-testid="text-settings-subtitle">
+      Manage your application settings.
+    </p>
+  </div>
+
+  <div class="space-y-6">
+    <div class="grid w-full grid-cols-5">
+      <button
+        class="flex items-center justify-center p-2"
+        [ngClass]="activeTab === 'company' ? 'border-b-2 font-semibold' : 'border-b'"
+        (click)="setActiveTab('company')"
+        data-testid="tab-company"
+      >
+        <svg
+          class="w-4 h-4 mr-2"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M3 21h18" />
+          <path d="M6 21V9h4v12" />
+          <path d="M14 21V3h4v18" />
+          <path d="M10 13h4" />
+        </svg>
+        Company
+      </button>
+      <button
+        class="flex items-center justify-center p-2"
+        [ngClass]="activeTab === 'team' ? 'border-b-2 font-semibold' : 'border-b'"
+        (click)="setActiveTab('team')"
+        data-testid="tab-team"
+      >
+        <svg
+          class="w-4 h-4 mr-2"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="9" cy="7" r="4" />
+          <path d="M17 11v-1a4 4 0 0 0-4-4" />
+          <path d="M2 21v-2a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4v2" />
+          <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+        </svg>
+        Team
+      </button>
+      <button
+        class="flex items-center justify-center p-2"
+        [ngClass]="activeTab === 'security' ? 'border-b-2 font-semibold' : 'border-b'"
+        (click)="setActiveTab('security')"
+        data-testid="tab-security"
+      >
+        <svg
+          class="w-4 h-4 mr-2"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+        Security
+      </button>
+      <button
+        class="flex items-center justify-center p-2"
+        [ngClass]="activeTab === 'notifications' ? 'border-b-2 font-semibold' : 'border-b'"
+        (click)="setActiveTab('notifications')"
+        data-testid="tab-notifications"
+      >
+        <svg
+          class="w-4 h-4 mr-2"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        Notifications
+      </button>
+      <button
+        class="flex items-center justify-center p-2"
+        [ngClass]="activeTab === 'language' ? 'border-b-2 font-semibold' : 'border-b'"
+        (click)="setActiveTab('language')"
+        data-testid="tab-language"
+      >
+        <svg
+          class="w-4 h-4 mr-2"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M2 12h20" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10" />
+        </svg>
+        Language
+      </button>
+    </div>
+
+    @if (activeTab === 'company') {
+      <div class="space-y-6">
+        <div class="bg-white rounded-lg shadow-md" data-testid="card-company-info">
+          <div class="p-6 border-b">
+            <h2 class="text-lg font-semibold">Company Info</h2>
+          </div>
+          <form class="p-6 space-y-4" [formGroup]="companyForm" (ngSubmit)="saveCompany()">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div class="space-y-2">
+                <label for="company-name" class="block text-sm font-medium">Company Name</label>
+                <input
+                  id="company-name"
+                  type="text"
+                  class="w-full border rounded-md px-3 py-2"
+                  formControlName="name"
+                  data-testid="input-company-name"
+                />
+              </div>
+              <div class="space-y-2">
+                <label for="company-website" class="block text-sm font-medium">Website</label>
+                <input
+                  id="company-website"
+                  type="text"
+                  class="w-full border rounded-md px-3 py-2"
+                  formControlName="website"
+                  data-testid="input-company-website"
+                />
+              </div>
+            </div>
+            <div class="space-y-2">
+              <label for="company-description" class="block text-sm font-medium">Description</label>
+              <textarea
+                id="company-description"
+                rows="4"
+                class="w-full border rounded-md px-3 py-2"
+                formControlName="description"
+                placeholder="Company description"
+                data-testid="textarea-company-description"
+              ></textarea>
+            </div>
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-blue-600 text-white"
+              data-testid="button-save-company"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+                <path d="M17 21v-8H7v8" />
+                <path d="M7 3v5h8" />
+              </svg>
+              Save changes
+            </button>
+          </form>
+        </div>
+      </div>
+    }
+
+    @if (activeTab === 'team') {
+      <div class="space-y-6">
+        <div class="bg-white rounded-lg shadow-md" data-testid="card-team-settings">
+          <div class="p-6 border-b">
+            <h2 class="text-lg font-semibold">Team Settings</h2>
+          </div>
+          <form class="p-6 space-y-4" [formGroup]="teamForm" (ngSubmit)="saveTeam()">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Automatically add members</label>
+                <p class="text-sm settings-hint">Automatically add new members to the team.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="autoAddMembers"
+                  data-testid="switch-auto-add-members"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="teamForm.get('autoAddMembers')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="teamForm.get('autoAddMembers')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Require approval</label>
+                <p class="text-sm settings-hint">Require admin approval for new members.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="requireApproval"
+                  data-testid="switch-require-approval"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="teamForm.get('requireApproval')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="teamForm.get('requireApproval')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-blue-600 text-white"
+              data-testid="button-save-team"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+                <path d="M17 21v-8H7v8" />
+                <path d="M7 3v5h8" />
+              </svg>
+              Save changes
+            </button>
+          </form>
+        </div>
+      </div>
+    }
+
+    @if (activeTab === 'security') {
+      <div class="space-y-6">
+        <div class="bg-white rounded-lg shadow-md" data-testid="card-security-settings">
+          <div class="p-6 border-b">
+            <h2 class="text-lg font-semibold">Security Settings</h2>
+          </div>
+          <form class="p-6 space-y-4" [formGroup]="securityForm" (ngSubmit)="saveSecurity()">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Two-factor authentication</label>
+                <p class="text-sm settings-hint">Require an additional login step.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="twoFactor"
+                  data-testid="switch-2fa"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="securityForm.get('twoFactor')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="securityForm.get('twoFactor')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Session timeout</label>
+                <p class="text-sm settings-hint">Log out inactive users automatically.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="sessionTimeout"
+                  data-testid="switch-session-timeout"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="securityForm.get('sessionTimeout')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="securityForm.get('sessionTimeout')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">IP restrictions</label>
+                <p class="text-sm settings-hint">Limit access to specific IP addresses.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="ipRestrictions"
+                  data-testid="switch-ip-restrictions"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="securityForm.get('ipRestrictions')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="securityForm.get('ipRestrictions')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-blue-600 text-white"
+              data-testid="button-save-security"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+                <path d="M17 21v-8H7v8" />
+                <path d="M7 3v5h8" />
+              </svg>
+              Save changes
+            </button>
+          </form>
+        </div>
+      </div>
+    }
+
+    @if (activeTab === 'notifications') {
+      <div class="space-y-6">
+        <div class="bg-white rounded-lg shadow-md" data-testid="card-notification-settings">
+          <div class="p-6 border-b">
+            <h2 class="text-lg font-semibold">Notification Preferences</h2>
+          </div>
+          <form class="p-6 space-y-4" [formGroup]="notificationsForm" (ngSubmit)="saveNotifications()">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Pipeline failures</label>
+                <p class="text-sm settings-hint">Notify on pipeline execution errors.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="pipelineFailures"
+                  data-testid="switch-pipeline-failures"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="notificationsForm.get('pipelineFailures')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="notificationsForm.get('pipelineFailures')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Security alerts</label>
+                <p class="text-sm settings-hint">Notify on potential security issues.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="securityAlerts"
+                  data-testid="switch-security-alerts"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="notificationsForm.get('securityAlerts')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="notificationsForm.get('securityAlerts')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="block text-sm font-medium">Weekly reports</label>
+                <p class="text-sm settings-hint">Receive summary reports every week.</p>
+              </div>
+              <label class="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only"
+                  formControlName="weeklyReports"
+                  data-testid="switch-weekly-reports"
+                />
+                <div
+                  class="w-10 h-6 bg-gray-200 rounded-full p-1 transition"
+                  [class.bg-blue-600]="notificationsForm.get('weeklyReports')?.value"
+                >
+                  <div
+                    class="w-4 h-4 bg-white rounded-full transition-transform"
+                    [class.translate-x-4]="notificationsForm.get('weeklyReports')?.value"
+                  ></div>
+                </div>
+              </label>
+            </div>
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-blue-600 text-white"
+              data-testid="button-save-notifications"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+                <path d="M17 21v-8H7v8" />
+                <path d="M7 3v5h8" />
+              </svg>
+              Save changes
+            </button>
+          </form>
+        </div>
+      </div>
+    }
+
+    @if (activeTab === 'language') {
+      <div class="space-y-6">
+        <div class="bg-white rounded-lg shadow-md" data-testid="card-language-settings">
+          <div class="p-6 border-b">
+            <h2 class="text-lg font-semibold">Language Settings</h2>
+          </div>
+          <form class="p-6 space-y-4" [formGroup]="languageForm" (ngSubmit)="saveLanguage()">
+            <div class="space-y-2">
+              <label class="block text-sm font-medium">Select language</label>
+              <select
+                class="w-48 border rounded-md px-3 py-2"
+                formControlName="language"
+                (change)="setLanguage(languageForm.get('language')?.value)"
+                data-testid="select-language"
+              >
+                <option value="en">English</option>
+                <option value="ru">Русский</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-full px-3 py-2 bg-blue-600 text-white"
+              data-testid="button-save-language"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+                <path d="M17 21v-8H7v8" />
+                <path d="M7 3v5h8" />
+              </svg>
+              Save changes
+            </button>
+          </form>
+        </div>
+      </div>
+    }
+  </div>
+</div>
+

--- a/frontend/admin/src/app/pages/settings/settings.component.scss
+++ b/frontend/admin/src/app/pages/settings/settings.component.scss
@@ -1,0 +1,10 @@
+@use 'styles/variables' as *;
+
+.settings-title {
+  color: $text-main-color;
+}
+
+.settings-hint {
+  color: $muted-text-color;
+}
+

--- a/frontend/admin/src/app/pages/settings/settings.component.ts
+++ b/frontend/admin/src/app/pages/settings/settings.component.ts
@@ -1,13 +1,88 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule, ReactiveFormsModule],
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SettingsComponent {}
+export class SettingsComponent {
+  // TODO: i18n
+  activeTab = 'company';
+
+  language = 'en';
+
+  companyForm: FormGroup;
+  teamForm: FormGroup;
+  securityForm: FormGroup;
+  notificationsForm: FormGroup;
+  languageForm: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.companyForm = this.fb.group({
+      name: ['Acme Corporation'],
+      website: ['https://acme.com'],
+      description: [
+        this.language === 'ru'
+          ? 'Ведущая технологическая компания, специализирующаяся на инновационных решениях.'
+          : 'Leading technology company focused on innovative solutions.',
+      ],
+    });
+
+    this.teamForm = this.fb.group({
+      autoAddMembers: [false],
+      requireApproval: [true],
+    });
+
+    this.securityForm = this.fb.group({
+      twoFactor: [true],
+      sessionTimeout: [true],
+      ipRestrictions: [false],
+    });
+
+    this.notificationsForm = this.fb.group({
+      pipelineFailures: [true],
+      securityAlerts: [true],
+      weeklyReports: [true],
+    });
+
+    this.languageForm = this.fb.group({
+      language: [this.language],
+    });
+  }
+
+  setActiveTab(tab: string) {
+    this.activeTab = tab;
+  }
+
+  saveCompany() {
+    console.log(this.companyForm.value);
+  }
+
+  saveTeam() {
+    console.log(this.teamForm.value);
+  }
+
+  saveSecurity() {
+    console.log(this.securityForm.value);
+  }
+
+  saveNotifications() {
+    console.log(this.notificationsForm.value);
+  }
+
+  saveLanguage() {
+    console.log(this.languageForm.value);
+  }
+
+  setLanguage(lang: string) {
+    this.language = lang;
+    this.languageForm.patchValue({ language: lang });
+  }
+}
+


### PR DESCRIPTION
## Summary
- migrate settings page from React to Angular standalone component
- build reactive forms for company, team, security, notifications and language sections
- replace UI library elements with native elements styled by Tailwind

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d5bdef5883218c947724bd8b7e62