### PR TITLE
feat: migrate projects page to standalone Angular component

### DIFF
--- a/frontend/admin/src/app/pages/projects/projects.component.html
+++ b/frontend/admin/src/app/pages/projects/projects.component.html
@@ -1,0 +1,88 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-6xl mx-auto p-4 sm:p-6">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold page-title">Projects</h1>
+      <button
+        class="inline-flex items-center gap-2 rounded-full px-4 py-2 bg-blue-600 text-white hover:bg-blue-700"
+        (click)="createProject()"
+      >
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M12 5v14M5 12h14"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+        <span>Create</span>
+      </button>
+    </div>
+
+    <div class="flex flex-col sm:flex-row gap-3 sm:items-center mb-6">
+      <div class="relative flex-1">
+        <input
+          [ngModel]="query()"
+          (ngModelChange)="query.set($event)"
+          type="text"
+          placeholder="Search projects..."
+          class="w-full border border-gray-200 rounded-md px-3 py-2 pl-9 bg-white"
+        />
+        <svg
+          class="w-4 h-4 absolute left-3 top-2.5 text-gray-400"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <path
+            d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28.79.79L20 20.5 21.5 19l-6-6z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      <select
+        [ngModel]="tag()"
+        (ngModelChange)="tag.set($event)"
+        class="border border-gray-200 rounded-md px-3 py-2 bg-white"
+      >
+        <option value="all">All</option>
+        <option value="active">Active</option>
+        <option value="archived">Archived</option>
+      </select>
+      <select
+        [ngModel]="sort()"
+        (ngModelChange)="sort.set($event)"
+        class="border border-gray-200 rounded-md px-3 py-2 bg-white"
+      >
+        <option value="updated">Sort by: Updated</option>
+        <option value="name">Sort by: Name</option>
+      </select>
+    </div>
+
+    @if (filtered().length === 0) {
+      <div class="text-sm text-gray-500">No projects found.</div>
+    } @else {
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        @for (p of filtered(); track trackById) {
+          <article
+            class="bg-white rounded-xl shadow-md hover:shadow-lg transition cursor-pointer"
+            (click)="openProject(p.id)"
+          >
+            <div class="p-5">
+              <div class="flex items-start justify-between">
+                <h2 class="text-lg font-semibold page-title">{{ p.name }}</h2>
+                @if (p.status === 'archived') {
+                  <span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">Archived</span>
+                }
+              </div>
+              @if (p.description) {
+                <p class="mt-2 text-sm text-gray-600">{{ p.description }}</p>
+              }
+              <div class="mt-4 text-xs text-gray-400">
+                @if (p.updatedAt) { <span>Updated {{ p.updatedAt }}</span> }
+              </div>
+            </div>
+          </article>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/admin/src/app/pages/projects/projects.component.scss
+++ b/frontend/admin/src/app/pages/projects/projects.component.scss
@@ -1,0 +1,5 @@
+@use 'styles/variables' as *;
+
+.page-title {
+  color: $text-main-color;
+}

--- a/frontend/admin/src/app/pages/projects/projects.component.ts
+++ b/frontend/admin/src/app/pages/projects/projects.component.ts
@@ -1,13 +1,86 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+
+type Project = {
+  id: string;
+  name: string;
+  description?: string;
+  updatedAt?: string;
+  status?: 'active' | 'archived';
+};
 
 @Component({
   selector: 'app-projects',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './projects.component.html',
   styleUrls: ['./projects.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProjectsComponent {}
+export class ProjectsComponent {
+  private readonly router = inject(Router);
+
+  projects = signal<Project[]>([
+    {
+      id: '1',
+      name: 'Alpha Project',
+      description: 'First project',
+      updatedAt: '2024-06-01',
+      status: 'active',
+    },
+    {
+      id: '2',
+      name: 'Beta Project',
+      description: 'Second project',
+      updatedAt: '2024-05-20',
+      status: 'archived',
+    },
+    {
+      id: '3',
+      name: 'Gamma Project',
+      description: 'Third project',
+      updatedAt: '2024-05-25',
+      status: 'active',
+    },
+  ]);
+  // TODO: load projects from API (без внешних пакетов)
+
+  query = signal('');
+  tag = signal<'all' | 'active' | 'archived'>('all');
+  sort = signal<'updated' | 'name'>('updated');
+
+  filtered = computed(() => {
+    let list = this.projects();
+    const q = this.query().toLowerCase();
+    if (q) {
+      list = list.filter(p =>
+        p.name.toLowerCase().includes(q) || p.description?.toLowerCase().includes(q)
+      );
+    }
+    const tag = this.tag();
+    if (tag !== 'all') {
+      list = list.filter(p => p.status === tag);
+    }
+    const sort = this.sort();
+    return [...list].sort((a, b) => {
+      if (sort === 'name') {
+        return a.name.localeCompare(b.name);
+      }
+      const ad = a.updatedAt ? Date.parse(a.updatedAt) : 0;
+      const bd = b.updatedAt ? Date.parse(b.updatedAt) : 0;
+      return bd - ad;
+    });
+  });
+
+  trackById = (_: number, p: { id: string }) => p.id;
+
+  createProject() {
+    this.router.navigate(['/create-project']);
+  }
+
+  openProject(id: string) {
+    this.router.navigate(['/project-detail', id]);
+  }
+}

--- a/frontend/admin/src/styles/_variables.scss
+++ b/frontend/admin/src/styles/_variables.scss
@@ -5,6 +5,7 @@ $yellow-color: #ffe100;
 $text-main-color: #111827;  // gray-900
 $muted-text-color: #6b7280; // gray-600
 $danger-color: #ef4444;     // red-500
+$primary-color: #2563eb;    // blue-600
 $surface-bg: #ffffff;
 $page-bg: #f9fafb;          // gray-50
 $radius-md: 0.75rem;        // 12px


### PR DESCRIPTION
## Summary
- add standalone ProjectsComponent with signals, search and filtering
- expose SCSS color variables and apply them via local styles

## Testing
- `npm test`
- `npm run build` *(fails: Can't bind to 'testid' in help.component.html)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d8a9f238832183fff1d4aee09ebd