### PR TITLE
feat: add standalone dashboard page

### DIFF
--- a/frontend/admin/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/admin/src/app/pages/dashboard/dashboard.component.html
@@ -1,0 +1,141 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-6xl mx-auto p-4 sm:p-6 space-y-6">
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold" style="color:$text-main-color;">Dashboard</h1>
+      <div class="flex items-center gap-2">
+        @for (a of quick(); track a.id) {
+          <button
+            class="inline-flex items-center gap-2 rounded-full px-4 py-2 bg-blue-600 text-white hover:bg-blue-700"
+            (click)="go(a.to)"
+          >
+            @if (a.icon === 'plus') {
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none">
+                <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+              </svg>
+            }
+            @if (a.icon === 'pipeline') {
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="6" cy="6" r="2" />
+                <path d="M6 8v8" />
+                <circle cx="6" cy="18" r="2" />
+                <path d="M6 12h8" />
+                <circle cx="18" cy="12" r="2" />
+              </svg>
+            }
+            <span>{{ a.label }}</span>
+          </button>
+        }
+      </div>
+    </div>
+
+    <!-- Summary cards -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      @for (s of summary(); track s.label) {
+        <div class="bg-white rounded-xl shadow-md p-5">
+          <div class="text-sm" style="color:$muted-text-color;">{{ s.label }}</div>
+          <div class="mt-1 text-2xl font-semibold text-gray-900">{{ s.value }}</div>
+        </div>
+      }
+    </div>
+
+    <!-- Two columns -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Recent runs -->
+      <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+          <div>
+            <h2 class="text-lg font-semibold" style="color:$text-main-color;">Recent runs</h2>
+            <p class="text-sm" style="color:$muted-text-color;">Latest pipeline activity</p>
+          </div>
+          <div class="relative">
+            <input
+              [ngModel]="query()"
+              (ngModelChange)="query.set($event)"
+              placeholder="Search…"
+              class="w-56 border border-gray-200 rounded-md px-3 py-2 pl-9 bg-white"
+            />
+            <svg class="w-4 h-4 absolute left-3 top-2.5 text-gray-400" viewBox="0 0 24 24" fill="none">
+              <path
+                d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28.79.79L20 20.5 21.5 19l-6-6z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </div>
+        <div class="divide-y divide-gray-100">
+          @if (filteredRuns().length) {
+            @for (r of filteredRuns(); track r.id) {
+              <div class="px-6 py-4 flex items-center gap-3 hover:bg-gray-50">
+                <div class="flex-1">
+                  <div class="text-gray-900 font-medium">#{{ r.id }} · {{ r.pipeline }}</div>
+                  <div class="text-sm" style="color:$muted-text-color;">{{ r.when }}</div>
+                </div>
+                <div>
+                  @if (r.status === 'running') {
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Running</span>
+                  }
+                  @if (r.status === 'success') {
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-green-50 text-green-700">Success</span>
+                  }
+                  @if (r.status === 'failed') {
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">Failed</span>
+                  }
+                </div>
+                <button (click)="openRun(r.id)" class="text-sm text-blue-600 hover:underline">Details</button>
+              </div>
+            }
+          } @else {
+            <div class="px-6 py-6 text-sm" style="color:$muted-text-color;">No runs yet.</div>
+          }
+        </div>
+      </section>
+
+      <!-- Recent projects -->
+      <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200">
+          <h2 class="text-lg font-semibold" style="color:$text-main-color;">Recent projects</h2>
+          <p class="text-sm" style="color:$muted-text-color;">Quick access</p>
+        </div>
+        <div class="divide-y divide-gray-100">
+          @if (recentProjects().length) {
+            @for (p of recentProjects(); track p.id) {
+              <div class="px-6 py-4 flex items-center justify-between hover:bg-gray-50">
+                <div>
+                  <div class="text-gray-900 font-medium">{{ p.name }}</div>
+                  @if (p.updatedAt) {
+                    <div class="text-sm" style="color:$muted-text-color;">Updated {{ p.updatedAt }}</div>
+                  }
+                </div>
+                <button (click)="openProject(p.id)" class="text-sm text-blue-600 hover:underline">
+                  Open
+                </button>
+              </div>
+            }
+          } @else {
+            <div class="px-6 py-6 text-sm" style="color:$muted-text-color;">No projects yet.</div>
+          }
+        </div>
+      </section>
+    </div>
+
+    <!-- (optional) Placeholder under graph/statistics -->
+    <section class="bg-white border border-gray-200 rounded-lg p-6">
+      <h2 class="text-lg font-semibold mb-2" style="color:$text-main-color;">Activity</h2>
+      <div
+        class="h-48 bg-gray-50 border border-dashed border-gray-200 rounded-md grid place-items-center text-sm"
+        style="color:$gray-color;"
+      >
+        Chart placeholder · TODO: integrate charts
+      </div>
+    </section>
+  </div>
+</div>

--- a/frontend/admin/src/app/pages/dashboard/dashboard.component.scss
+++ b/frontend/admin/src/app/pages/dashboard/dashboard.component.scss
@@ -1,0 +1,7 @@
+@use 'styles/variables' as *;
+
+:host {
+  display: block;
+}
+
+/* additional local styles if needed */

--- a/frontend/admin/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/admin/src/app/pages/dashboard/dashboard.component.ts
@@ -1,13 +1,65 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent {}
+export class DashboardComponent {
+  private readonly router = inject(Router);
+
+  summary = signal([
+    { label: 'Projects', value: 0 },
+    { label: 'Pipelines', value: 0 },
+    { label: 'Runs', value: 0 },
+    { label: 'Failures', value: 0 },
+  ]);
+
+  quick = signal([
+    { id: 'new-project', label: 'New Project', icon: 'plus', to: '/create-project' },
+    { id: 'pipelines', label: 'Pipelines', icon: 'pipeline', to: '/all-pipelines' },
+  ]);
+
+  recentRuns = signal<
+    { id: string; pipeline: string; status: 'success' | 'failed' | 'running'; when: string }[]
+  >([]);
+  recentProjects = signal<
+    { id: string; name: string; updatedAt?: string }[]
+  >([]);
+
+  query = signal('');
+  filteredRuns = computed(() => {
+    const q = this.query().toLowerCase();
+    return this.recentRuns().filter(r =>
+      !q || r.id.includes(q) || r.pipeline.toLowerCase().includes(q)
+    );
+  });
+
+  go(to: string) {
+    this.router.navigateByUrl(to);
+  }
+
+  openProject(id: string) {
+    this.router.navigate(['project-detail', id]);
+  }
+
+  openRun(id: string) {
+    // TODO: /runs/:id
+    this.router.navigate(['/runs', id]);
+  }
+
+  // TODO: load data from API
+  // TODO: i18n
+}


### PR DESCRIPTION
## Summary
- implement DashboardComponent with signals and navigation
- build Tailwind-based dashboard template
- add scoped styles using global variables

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7ea6c84b08321835e0c8571fc7e38