### PR TITLE
feat: add runs page

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -28,6 +28,11 @@ export const routes: Routes = [
       import('./pages/pipeline-detail/pipeline-detail.component').then(m => m.PipelineDetailComponent),
   },
   {
+    path: 'runs',
+    loadComponent: () =>
+      import('./pages/runs/runs.component').then(m => m.RunsComponent),
+  },
+  {
     path: 'create-project',
     loadComponent: () =>
       import('./pages/create-project/create-project.component').then(m => m.CreateProjectComponent),
@@ -54,3 +59,4 @@ export const routes: Routes = [
   },
   { path: '**', redirectTo: 'not-found' },
 ];
+

--- a/frontend/admin/src/app/pages/runs/runs.component.html
+++ b/frontend/admin/src/app/pages/runs/runs.component.html
@@ -1,0 +1,137 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-6xl mx-auto p-4 sm:p-6 space-y-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold page-title">Runs</h1>
+      <div class="text-sm" style="color:$muted-text-color;">
+        {{ filtered().length }} results
+      </div>
+    </div>
+
+    <div class="flex flex-col sm:flex-row gap-3 sm:items-center">
+      <div class="relative flex-1">
+        <input
+          [ngModel]="query()"
+          (ngModelChange)="query.set($event)"
+          type="text"
+          placeholder="Search runs, pipelines, projects…"
+          class="w-full border border-gray-200 rounded-md px-3 py-2 pl-9 bg-white"
+        />
+        <svg class="w-4 h-4 absolute left-3 top-2.5 text-gray-400" viewBox="0 0 24 24" fill="none">
+          <path d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28.79.79L20 20.5 21.5 19l-6-6z" fill="currentColor" />
+        </svg>
+      </div>
+
+      <select
+        [ngModel]="status()"
+        (ngModelChange)="status.set($event)"
+        class="border border-gray-200 rounded-md px-3 py-2 bg-white"
+      >
+        <option value="all">All statuses</option>
+        <option value="running">Running</option>
+        <option value="success">Success</option>
+        <option value="failed">Failed</option>
+        <option value="canceled">Canceled</option>
+      </select>
+
+      <select
+        [ngModel]="sort()"
+        (ngModelChange)="sort.set($event)"
+        class="border border-gray-200 rounded-md px-3 py-2 bg-white"
+      >
+        <option value="started">Sort by: Started</option>
+        <option value="finished">Sort by: Finished</option>
+        <option value="status">Sort by: Status</option>
+        <option value="pipeline">Sort by: Pipeline</option>
+      </select>
+    </div>
+
+    <div class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="text-left py-3 px-6 font-medium text-gray-600">Run</th>
+              <th class="text-left py-3 px-6 font-medium text-gray-600">Pipeline</th>
+              <th class="text-left py-3 px-6 font-medium text-gray-600">Project</th>
+              <th class="text-left py-3 px-6 font-medium text-gray-600">Status</th>
+              <th class="text-left py-3 px-6 font-medium text-gray-600">Started</th>
+              <th class="text-left py-3 px-6 font-medium text-gray-600">Finished</th>
+              <th class="text-right py-3 px-6 font-medium text-gray-600">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @if (filtered().length) {
+              @for (r of filtered(); track r.id) {
+                <tr class="border-t border-gray-100 hover:bg-gray-50">
+                  <td class="py-3 px-6 text-gray-900">#{{ r.id }}</td>
+                  <td class="py-3 px-6">
+                    <button class="text-blue-600 hover:underline" (click)="openPipeline(r.pipeline)">
+                      {{ r.pipeline }}
+                    </button>
+                  </td>
+                  <td class="py-3 px-6">
+                    @if (r.project) {
+                      <button class="text-blue-600 hover:underline" (click)="openProject(r.project!)">
+                        {{ r.project }}
+                      </button>
+                    } @else {
+                      <span class="text-gray-400">—</span>
+                    }
+                  </td>
+                  <td class="py-3 px-6">
+                    @if (r.status === 'running') {
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Running</span>
+                    }
+                    @if (r.status === 'success') {
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-green-50 text-green-700">Success</span>
+                    }
+                    @if (r.status === 'failed') {
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">Failed</span>
+                    }
+                    @if (r.status === 'canceled') {
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">Canceled</span>
+                    }
+                  </td>
+                  <td class="py-3 px-6 text-gray-700">{{ r.startedAt || '—' }}</td>
+                  <td class="py-3 px-6 text-gray-700">{{ r.finishedAt || '—' }}</td>
+                  <td class="py-3 px-6 text-right">
+                    <div class="inline-flex gap-2">
+                      <button (click)="openRun(r.id)" class="text-sm text-blue-600 hover:underline">
+                        Details
+                      </button>
+                      <button
+                        (click)="rerun(r.id)"
+                        class="inline-flex items-center gap-2 rounded-full px-3 py-1.5 border border-gray-200 hover:bg-white"
+                      >
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none">
+                          <path d="M8 5v14l11-7-11-7z" fill="currentColor" />
+                        </svg>
+                        <span>Re-run</span>
+                      </button>
+                      <button
+                        (click)="cancel(r.id)"
+                        class="inline-flex items-center gap-2 rounded-full px-3 py-1.5 border border-gray-200 hover:bg-white"
+                      >
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none">
+                          <rect x="7" y="7" width="10" height="10" fill="currentColor" />
+                        </svg>
+                        <span>Cancel</span>
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            } @else {
+              <tr class="border-t border-gray-100">
+                <td colspan="7" class="py-6 px-6 text-sm" style="color:$muted-text-color;">
+                  No runs found.
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/frontend/admin/src/app/pages/runs/runs.component.scss
+++ b/frontend/admin/src/app/pages/runs/runs.component.scss
@@ -1,0 +1,6 @@
+@use 'styles/variables' as *;
+
+.page-title {
+  color: $text-main-color;
+}
+

--- a/frontend/admin/src/app/pages/runs/runs.component.ts
+++ b/frontend/admin/src/app/pages/runs/runs.component.ts
@@ -1,0 +1,92 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+
+type Run = {
+  id: string;
+  pipeline: string;
+  project?: string;
+  status: 'running' | 'success' | 'failed' | 'canceled';
+  startedAt?: string;
+  finishedAt?: string;
+  author?: string;
+};
+
+@Component({
+  selector: 'app-runs',
+  standalone: true,
+  imports: [CommonModule, RouterModule, FormsModule],
+  templateUrl: './runs.component.html',
+  styleUrls: ['./runs.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RunsComponent {
+  private readonly router = inject(Router);
+
+  query = signal('');
+  status = signal<'all' | 'running' | 'success' | 'failed' | 'canceled'>('all');
+  sort = signal<'started' | 'finished' | 'status' | 'pipeline'>('started');
+
+  runs = signal<Run[]>([
+    // TODO: mock; replace with API
+  ]);
+
+  filtered = computed(() => {
+    let list = this.runs();
+    const q = this.query().toLowerCase();
+    if (q) {
+      list = list.filter(r =>
+        r.id.toLowerCase().includes(q) ||
+        r.pipeline.toLowerCase().includes(q) ||
+        r.project?.toLowerCase().includes(q)
+      );
+    }
+    const st = this.status();
+    if (st !== 'all') {
+      list = list.filter(r => r.status === st);
+    }
+    const sort = this.sort();
+    return [...list].sort((a, b) => {
+      switch (sort) {
+        case 'finished':
+          return compareDateDesc(a.finishedAt, b.finishedAt);
+        case 'status':
+          return a.status.localeCompare(b.status);
+        case 'pipeline':
+          return a.pipeline.localeCompare(b.pipeline);
+        default:
+          return compareDateDesc(a.startedAt, b.startedAt);
+      }
+    });
+  });
+
+  trackById = (_: number, r: Run) => r.id;
+
+  openRun(id: string) {
+    this.router.navigate(['runs', id]);
+  }
+
+  openPipeline(nameOrId: string) {
+    this.router.navigate(['pipeline-detail', nameOrId]);
+  }
+
+  openProject(nameOrId: string) {
+    this.router.navigate(['project-detail', nameOrId]);
+  }
+
+  rerun(id: string) {
+    // TODO: trigger re-run
+  }
+
+  cancel(id: string) {
+    // TODO: cancel run
+  }
+}
+
+function compareDateDesc(a?: string, b?: string) {
+  const ad = a ? Date.parse(a) : 0;
+  const bd = b ? Date.parse(b) : 0;
+  return bd - ad;
+}
+


### PR DESCRIPTION
## Summary
- add standalone RunsComponent with filtering, sorting, and actions
- wire /runs route

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eeaa182483218ca1c61e28934314