### PR TITLE
feat: implement dark theme and header component

### DIFF
--- a/frontend/admin/src/app/layout/app-layout.component.html
+++ b/frontend/admin/src/app/layout/app-layout.component.html
@@ -5,13 +5,13 @@
     class="app-sidebar fixed inset-y-0 left-0 w-64 h-screen z-50 border-r backdrop-blur p-4"
     (click)="$event.stopPropagation()"
   >
-    <div class="flex flex-col h-full">
+    <div class="flex flex-col h-full px-4 py-6">
       <div class="flex items-center justify-between mb-4">
         <a [routerLink]="['/dashboard']" class="flex items-center gap-3">
-          <img ngSrc="assets/logo.png" alt="Logo" class="h-8 w-auto object-contain" height="450" width="2198" priority />
+          <img ngSrc="assets/logo.png" width="32" height="32" class="h-8 w-auto object-contain" alt="Logo" />
           <span class="font-semibold">App</span>
         </a>
-        <button class="p-2 rounded-md hover:bg-gray-100" (click)="closeSidebar()">
+        <button class="h-8 w-8 grid place-items-center rounded-md hover:bg-white/5" (click)="closeSidebar()">
           <svg
             class="w-4 h-4"
             viewBox="0 0 24 24"
@@ -26,12 +26,12 @@
         </button>
       </div>
 
-      <nav class="flex-1 space-y-2">
+      <nav class="flex-1 mt-6 px-2 space-y-2">
         @for (i of nav; track i.id) {
           <a
             [routerLink]="[i.to]"
             routerLinkActive="is-active"
-            class="nav-btn flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white"
             (click)="closeSidebar()"
           >
             @switch (i.icon) {
@@ -137,12 +137,12 @@
           </a>
         }
 
-        <div class="pt-4 mt-4 border-t space-y-2">
+        <div class="pt-4 mt-4 border-t px-2 space-y-2">
           @for (i of secondary; track i.id) {
             <a
               [routerLink]="[i.to]"
               routerLinkActive="is-active"
-              class="nav-btn flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+              class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white"
               (click)="closeSidebar()"
             >
               @switch (i.icon) {
@@ -184,22 +184,22 @@
   </aside>
 </div>
 
-<div class="min-h-screen bg-gray-50 text-gray-900">
+<div class="min-h-screen">
   <div class="flex">
     <!-- Desktop sidebar -->
     <aside class="app-sidebar hidden md:block md:sticky md:top-0 md:h-screen w-64 border-r backdrop-blur">
       <div class="flex flex-col h-full px-4 py-6">
         <a [routerLink]="['/dashboard']" class="flex items-center gap-3">
-          <img src="assets/logo.png" alt="Logo" class="h-8 w-auto object-contain" />
+          <img ngSrc="assets/logo.png" width="32" height="32" class="h-8 w-auto object-contain" alt="Logo" />
           <span class="font-semibold">App</span>
         </a>
 
-        <nav class="flex-1 mt-6 space-y-2">
+        <nav class="flex-1 mt-6 px-2 space-y-2">
           @for (i of nav; track i.id) {
             <a
               [routerLink]="[i.to]"
               routerLinkActive="is-active"
-              class="nav-btn flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+              class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white"
             >
               @switch (i.icon) {
                 @case ('home') {
@@ -304,12 +304,12 @@
             </a>
           }
 
-          <div class="pt-4 mt-4 border-t space-y-2">
+          <div class="pt-4 mt-4 border-t px-2 space-y-2">
             @for (i of secondary; track i.id) {
               <a
                 [routerLink]="[i.to]"
                 routerLinkActive="is-active"
-                class="nav-btn flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+                class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white"
               >
                 @switch (i.icon) {
                   @case ('settings') {
@@ -351,73 +351,7 @@
 
     <!-- Main -->
     <div class="flex-1 min-w-0">
-      <!-- Header -->
-      <header class="app-header border-b backdrop-blur">
-        <div class="flex h-16 items-center px-6">
-          <button class="md:hidden p-2 rounded-md hover:bg-gray-100" (click)="toggleSidebar()">
-            <svg
-              class="w-4 h-4"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M3 6h18M3 12h18M3 18h18" />
-            </svg>
-          </button>
-
-          <div class="ml-auto flex items-center gap-1">
-            <!-- Search -->
-            <button class="p-2 rounded-md hover:bg-gray-100">
-              <svg
-                class="w-4 h-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <circle cx="11" cy="11" r="8" />
-                <line x1="21" y1="21" x2="16.65" y2="16.65" />
-              </svg>
-            </button>
-            <!-- Bell -->
-            <button class="p-2 rounded-md hover:bg-gray-100">
-              <svg
-                class="w-4 h-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
-                <path d="M13.73 21a2 2 0 0 1-3.46 0" />
-              </svg>
-            </button>
-            <!-- Settings -->
-            <button class="p-2 rounded-md hover:bg-gray-100">
-              <svg
-                class="w-4 h-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z" />
-              </svg>
-            </button>
-            <!-- User -->
-            <div class="w-8 h-8 rounded-full bg-gray-200"></div>
-          </div>
-        </div>
-      </header>
+      <app-header (menu)="toggleSidebar()"></app-header>
 
       <main class="p-4 sm:p-6">
         <router-outlet></router-outlet>

--- a/frontend/admin/src/app/layout/app-layout.component.ts
+++ b/frontend/admin/src/app/layout/app-layout.component.ts
@@ -1,12 +1,13 @@
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { AppHeaderComponent } from './header/header.component';
 
 type NavItem = { id:string; label:string; to:string; icon:'home'|'folder'|'activity'|'settings'|'help'|'stats'|'runs' };
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [CommonModule, RouterModule, NgOptimizedImage],
+  imports: [CommonModule, RouterModule, NgOptimizedImage, AppHeaderComponent],
   templateUrl: './app-layout.component.html',
   styleUrls: ['./app-layout.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/admin/src/app/layout/header/header.component.html
+++ b/frontend/admin/src/app/layout/header/header.component.html
@@ -1,0 +1,101 @@
+<header class="app-header border-b backdrop-blur">
+  <div class="flex h-16 items-center px-6">
+    <button
+      class="md:hidden h-8 w-8 grid place-items-center rounded-md hover:bg-white/5"
+      (click)="onMenuClick()"
+      aria-label="Toggle sidebar"
+    >
+      <svg
+        class="w-4 h-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M3 6h18M3 12h18M3 18h18" />
+      </svg>
+    </button>
+
+    <div class="ml-auto flex items-center gap-1">
+      <button
+        class="h-8 w-8 grid place-items-center rounded-md hover:bg-white/5 md:hidden"
+        aria-label="Search"
+      >
+        <svg
+          class="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </button>
+
+      <div class="relative hidden md:block ml-3 w-80">
+        <svg
+          class="pointer-events-none absolute left-3 top-2.5 w-4 h-4 text-gray-400"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          class="h-9 w-80 rounded-md border border-white/10 bg-white/5 pl-9 pr-3 text-sm placeholder:text-gray-400 text-gray-100 focus:outline-none focus:ring-2 focus:ring-white/20"
+          placeholder="Search… (Ctrl+K)"
+          type="search"
+        />
+      </div>
+
+      <button class="h-8 w-8 grid place-items-center rounded-md hover:bg-white/5" aria-label="Notifications">
+        <svg
+          class="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+      </button>
+
+      <button class="h-8 w-8 grid place-items-center rounded-md hover:bg-white/5" aria-label="Settings">
+        <svg
+          class="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path
+            d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z"
+          />
+        </svg>
+      </button>
+
+      <img
+        ngSrc="assets/avatar.png"
+        width="32"
+        height="32"
+        class="w-8 h-8 rounded-full"
+        alt="Avatar"
+      />
+    </div>
+  </div>
+</header>
+

--- a/frontend/admin/src/app/layout/header/header.component.scss
+++ b/frontend/admin/src/app/layout/header/header.component.scss
@@ -1,0 +1,2 @@
+@use 'styles/variables' as *;
+

--- a/frontend/admin/src/app/layout/header/header.component.ts
+++ b/frontend/admin/src/app/layout/header/header.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [NgOptimizedImage],
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppHeaderComponent {
+  @Output() menu = new EventEmitter<void>();
+
+  onMenuClick(): void {
+    this.menu.emit();
+  }
+}
+

--- a/frontend/admin/src/index.html
+++ b/frontend/admin/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru" class="dark">
 <head>
   <meta charset="utf-8">
   <title>Admin</title>
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
-<body>
+<body class="min-h-screen font-sans bg-[#0f1114] text-gray-100">
   <app-root></app-root>
 </body>
 </html>

--- a/frontend/admin/src/styles.scss
+++ b/frontend/admin/src/styles.scss
@@ -6,5 +6,13 @@
 @import "tailwindcss";                /* не @use! */
 
 /* 3) В КОНЦЕ любые ваши глобальные правила */
+html, body { height: 100%; }
+body {
+  background-color: $bg-page;
+  color: $text-main-color;
+}
+
+/* Полупрозрачные поверхности */
 .app-header  { border-color: $border-color; background-color: $card-bg-50; }
 .app-sidebar { border-color: $border-color; background-color: $card-bg-30; }
+.is-active { background-color: rgba(255,255,255,.06); color: #fff; }

--- a/frontend/admin/src/styles/_variables.scss
+++ b/frontend/admin/src/styles/_variables.scss
@@ -1,18 +1,21 @@
-$gray-color: #9da1aa;
+$bg-page:        #0f1114;   // фон страницы
+$surface-1:      #16191d;   // тёмная поверхность (дропдауны/меню)
+$border-color:   #1f2329;   // тонкие границы
+$card-bg-30:     rgba(17, 19, 21, .30); // sidebar фон с blur
+$card-bg-50:     rgba(17, 19, 21, .50); // header фон с blur
+$text-main-color: #e5e7eb;
+$muted-text-color: #9da1aa;
+$accent-yellow:  #ffe100;   // если используется в брендинге
+
+// Legacy tokens
+$page-bg: $bg-page;
+$surface-bg: $surface-1;
+$gray-color: $muted-text-color;
 $dark-gray-color: #6d7179;
-$yellow-color: #ffe100;
-
-$border-color: #e5e7eb;   // instead of border-border
-$card-bg: #ffffff;        // base "card"
-$card-bg-30: rgba(255,255,255,.30); // bg-card/30
-$card-bg-50: rgba(255,255,255,.50); // bg-card/50
-
-$text-main-color: #111827;  // gray-900
-$muted-text-color: #6b7280; // gray-600
-$danger-color: #ef4444;     // red-500
-$primary-color: #2563eb;    // blue-600
-$success-color: #16a34a;    // green-600
-$surface-bg: #ffffff;
-$page-bg: #f9fafb;          // gray-50
+$yellow-color: $accent-yellow;
+$danger-color: #ef4444;
+$primary-color: #2563eb;
+$success-color: #16a34a;
 $radius-md: 0.75rem;        // 12px
 $shadow-md: 0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -2px rgba(0,0,0,.05);
+


### PR DESCRIPTION
## Summary
- enable global dark theme and base color tokens
- add standalone AppHeader with search, icons and avatar
- restyle sidebar and layout to match React visual

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81d1fdbe4832195589851e4ed5789