### PR TITLE
feat: improve layout and tailwind

### DIFF
--- a/frontend/admin/src/app/layout/app-layout.component.html
+++ b/frontend/admin/src/app/layout/app-layout.component.html
@@ -1,46 +1,90 @@
-<div class="min-h-screen">
-  <div class="flex">
-    <!-- Левый сайдбар (desktop) -->
-    <app-sidebar [logoSrc]="'assets/logo.png'" [items]="nav"></app-sidebar>
-
-    <!-- Правая колонка -->
-    <div class="flex-1 min-w-0">
-      <app-header (menuToggle)="toggleSidebar()"></app-header>
-      <main class="p-4 sm:p-6">
-        <router-outlet></router-outlet>
-      </main>
+<div class="min-h-screen flex bg-[#0f1114] text-gray-100">
+  <!-- Desktop sidebar -->
+  <aside class="app-sidebar hidden md:flex md:flex-col shrink-0 w-64 md:sticky md:top-0 md:h-screen border-r border-white/10 bg-black/20 backdrop-blur">
+    <div class="px-4 py-6">
+      <a routerLink="/dashboard" class="flex items-center gap-2">
+        <img ngSrc="assets/logo.png" width="32" height="32" alt="Logo" class="h-8 w-auto" />
+        <span class="text-sm font-semibold">Merge Sensei</span>
+      </a>
     </div>
-  </div>
+
+    <nav class="px-2 space-y-1">
+      @for (i of nav; track i.id) {
+        <a [routerLink]="i.to"
+           routerLinkActive="is-active"
+           class="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+          <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            @switch (i.icon) {
+              @case ('dashboard') { <path d="M3 10l9-7 9 7v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/> }
+              @case ('projects') { <path d="M3 7V5a2 2 0 0 1 2-2h5l2 2h9v14H3Z"/> }
+              @case ('pipelines') { <path d="M22 12h-4l-3 9L9 3l-3 9H2"/> }
+              @case ('runs') { <circle cx="12" cy="12" r="10"/><path d="M13 12H7"/> }
+              @case ('stats') { <line x1="3" y1="22" x2="21" y2="22"/><rect x="7" y="10" width="2" height="6"/><rect x="11" y="6" width="2" height="10"/><rect x="15" y="13" width="2" height="3"/> }
+              @case ('settings') { <path d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z"/> }
+              @case ('help') { <circle cx="12" cy="12" r="10"/><path d="M9 9a3 3 0 1 1 3 3v2"/><line x1="12" y1="17" x2="12" y2="17"/> }
+            }
+          </svg>
+          <span>{{ i.label }}</span>
+        </a>
+      }
+    </nav>
+
+    <div class="mt-auto px-2 pt-4 pb-6 border-t border-white/10">
+      @for (i of secondary; track i.id) {
+        <a [routerLink]="i.to"
+           routerLinkActive="is-active"
+           class="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+          <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            @switch (i.icon) {
+              @case ('settings') { <path d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z"/> }
+              @case ('help') { <circle cx="12" cy="12" r="10"/><path d="M9 9a3 3 0 1 1 3 3v2"/><line x1="12" y1="17" x2="12" y2="17"/> }
+            }
+          </svg>
+          <span>{{ i.label }}</span>
+        </a>
+      }
+    </div>
+  </aside>
 
   <!-- Mobile drawer -->
-  <div class="md:hidden" [class.hidden]="!sidebarOpen()">
-    <div class="fixed inset-0 bg-black/40 z-40" (click)="sidebarOpen.set(false)"></div>
-    <aside class="app-sidebar fixed inset-y-0 left-0 z-50 w-64 p-4 border-r backdrop-blur">
-      <div class="px-4 py-6">
-        <a class="flex items-center gap-2">
-          <img src="assets/logo.png" alt="Logo" class="h-8 w-auto object-contain" width="32" height="32" />
-          <span class="sr-only">Home</span>
-        </a>
-      </div>
-      <div class="px-2 space-y-2">
-        @for (it of nav; track it.id) {
-          <a [routerLink]="[it.to]" (click)="sidebarOpen.set(false)" routerLinkActive="is-active"
-             class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white">
-            <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              @switch (it.icon) {
-                @case ('dashboard') { <path d="M3 10l9-7 9 7v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/> }
-                @case ('projects') { <path d="M3 7V5a2 2 0 0 1 2-2h5l2 2h9v14H3Z"/> }
-                @case ('pipelines') { <path d="M22 12h-4l-3 9L9 3l-3 9H2"/> }
-                @case ('runs') { <circle cx="12" cy="12" r="10"/><path d="M13 12H7"/> }
-                @case ('stats') { <line x1="3" y1="22" x2="21" y2="22"/><rect x="7" y="10" width="2" height="6"/><rect x="11" y="6" width="2" height="10"/><rect x="15" y="13" width="2" height="3"/> }
-                @case ('settings') { <path d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z"/> }
-                @case ('help') { <circle cx="12" cy="12" r="10"/><path d="M9 9a3 3 0 1 1 3 3v2"/><line x1="12" y1="17" x2="12" y2="17"/> }
-              }
-            </svg>
-            <span>{{ it.label }}</span>
+  @if (sidebarOpen) {
+    <div class="md:hidden">
+      <div class="fixed inset-0 z-40 bg-black/60" (click)="toggleSidebar()"></div>
+      <aside class="fixed inset-y-0 left-0 z-50 w-64 bg-[#0f1114] border-r border-white/10 p-4 overflow-y-auto">
+        <div class="flex items-center justify-between mb-4">
+          <a routerLink="/dashboard" class="flex items-center gap-2">
+            <img ngSrc="assets/logo.png" width="32" height="32" alt="Logo" class="h-8 w-auto" />
+            <span class="text-sm font-semibold">Merge Sensei</span>
           </a>
-        }
-      </div>
-    </aside>
+          <button class="h-8 w-8 rounded-md hover:bg-white/5" (click)="toggleSidebar()" aria-label="Close">✕</button>
+        </div>
+        <nav class="space-y-1">
+          @for (i of nav; track i.id) {
+            <a [routerLink]="i.to" (click)="toggleSidebar()"
+               routerLinkActive="is-active"
+               class="block px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+              {{ i.label }}
+            </a>
+          }
+          <div class="pt-3 mt-3 border-t border-white/10">
+            @for (i of secondary; track i.id) {
+              <a [routerLink]="i.to" (click)="toggleSidebar()"
+                 routerLinkActive="is-active"
+                 class="block px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+                {{ i.label }}
+              </a>
+            }
+          </div>
+        </nav>
+      </aside>
+    </div>
+  }
+
+  <!-- Content area -->
+  <div class="flex-1 min-w-0 flex flex-col">
+    <app-header (menuToggle)="toggleSidebar()"></app-header>
+    <main class="p-4 sm:p-6">
+      <router-outlet></router-outlet>
+    </main>
   </div>
 </div>

--- a/frontend/admin/src/app/layout/app-layout.component.scss
+++ b/frontend/admin/src/app/layout/app-layout.component.scss
@@ -1,4 +1,3 @@
 @use 'styles/variables' as *;
 
-.app-sidebar { border-color: $border-color; background-color: $card-bg-30; }
-.is-active   { background-color: rgba(255,255,255,.06); color: #fff; }
+.is-active { @apply bg-white/10 text-white; }

--- a/frontend/admin/src/app/layout/app-layout.component.ts
+++ b/frontend/admin/src/app/layout/app-layout.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AppHeaderComponent } from './header/header.component';
-import { SidebarComponent } from './sidebar/sidebar.component';
 
 type NavItem = {
   id: string;
@@ -20,16 +19,16 @@ type NavItem = {
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [CommonModule, RouterModule, AppHeaderComponent, SidebarComponent],
+  imports: [CommonModule, RouterModule, NgOptimizedImage, AppHeaderComponent],
   templateUrl: './app-layout.component.html',
   styleUrls: ['./app-layout.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppLayoutComponent {
-  sidebarOpen = signal(false);
+  sidebarOpen = false;
 
   toggleSidebar() {
-    this.sidebarOpen.update((v) => !v);
+    this.sidebarOpen = !this.sidebarOpen;
   }
 
   nav: NavItem[] = [
@@ -38,6 +37,9 @@ export class AppLayoutComponent {
     { id: 'pipelines', label: 'Pipelines', to: '/all-pipelines', icon: 'pipelines' },
     { id: 'runs', label: 'Runs', to: '/runs', icon: 'runs' },
     { id: 'stats', label: 'Stats', to: '/dashboard-stats', icon: 'stats' },
+  ];
+
+  secondary: NavItem[] = [
     { id: 'settings', label: 'Settings', to: '/settings', icon: 'settings' },
     { id: 'help', label: 'Help', to: '/help', icon: 'help' },
   ];

--- a/frontend/admin/src/app/layout/header/header.component.html
+++ b/frontend/admin/src/app/layout/header/header.component.html
@@ -21,7 +21,7 @@
       </button>
 
       <button class="ml-1 h-8 w-8 rounded-full hover:bg-white/5 grid place-items-center" aria-label="User menu">
-        <img src="assets/logo.png" width="32" height="32" class="w-8 h-8 rounded-full" alt="Avatar" />
+        <img ngSrc="assets/logo.png" width="32" height="32" class="w-8 h-8 rounded-full" alt="Avatar" />
       </button>
     </div>
   </div>

--- a/frontend/admin/src/styles.scss
+++ b/frontend/admin/src/styles.scss
@@ -1,11 +1,9 @@
-/* 1) СНАЧАЛА ваши SCSS-переменные */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @use 'styles/variables' as *;
 
-/* 2) ПОТОМ Tailwind v4 директивы (это CSS-директивы) */
-@config "../tailwind.v4.config.js";   /* путь от src/styles.scss к конфигу в корне */
-@import "tailwindcss";                /* не @use! */
-
-/* 3) В КОНЦЕ любые ваши глобальные правила */
 html, body { height: 100%; }
 body {
   background-color: $bg-page;

--- a/frontend/admin/tailwind.config.js
+++ b/frontend/admin/tailwind.config.js
@@ -1,0 +1,1 @@
+module.exports = { darkMode: 'class', content: ['./src/**/*.{html,ts}'], theme:{ extend:{} }, plugins:[] };


### PR DESCRIPTION
## Summary
- wire up Tailwind with standard config and directives
- redesign layout with sticky sidebar, header and mobile drawer
- ensure header image uses ngSrc

## Testing
- `cd frontend/admin && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b852ba55048321861b951d27509a84