### PR TITLE
feat(dashboard): KPI cards, recent activity and performance bars (tailwind v3, fluid)

### DIFF
--- a/frontend/admin/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/admin/src/app/pages/dashboard/dashboard.component.html
@@ -1,141 +1,104 @@
-<div class="min-h-screen bg-gray-50">
-  <div class="max-w-6xl mx-auto p-4 sm:p-6 space-y-6">
-    <!-- Header -->
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold" style="color:$text-main-color;">Dashboard</h1>
-      <div class="flex items-center gap-2">
-        @for (a of quick(); track a.id) {
-          <button
-            class="inline-flex items-center gap-2 rounded-full px-4 py-2 bg-blue-600 text-white hover:bg-blue-700"
-            (click)="go(a.to)"
-          >
-            @if (a.icon === 'plus') {
-              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none">
-                <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-              </svg>
-            }
-            @if (a.icon === 'pipeline') {
-              <svg
-                class="w-4 h-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <circle cx="6" cy="6" r="2" />
-                <path d="M6 8v8" />
-                <circle cx="6" cy="18" r="2" />
-                <path d="M6 12h8" />
-                <circle cx="18" cy="12" r="2" />
-              </svg>
-            }
-            <span>{{ a.label }}</span>
-          </button>
+<div class="w-full mx-auto px-4 sm:px-6 lg:px-8">
+  <!-- Page header -->
+  <header class="pt-8 pb-6">
+    <h1 class="text-3xl font-bold">Dashboard</h1>
+    <p class="mt-1 text-sm text-gray-400">Overview of your project and pipeline performance</p>
+  </header>
+
+  <!-- KPI cards -->
+  <section class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+    @for (s of stats; track s.id) {
+      <article class="rounded-xl border border-white/10 bg-white/[0.03] hover:bg-white/[0.06] transition-colors"
+               style="box-shadow:0 0 0 1px rgba(255,255,255,0.02) inset">
+        <div class="p-5">
+          <div class="flex items-start justify-between">
+            <div class="text-sm text-gray-400">{{ s.title }}</div>
+            <div class="text-gray-400">
+              @switch (s.icon) {
+                @case ('trend') { <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M19 7l-7 7-4-4-5 5"/></svg> }
+                @case ('activity') { <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg> }
+                @case ('code') { <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m7 8-4 4 4 4"/><path d="m17 8 4 4-4 4"/><path d="m14 4-4 16"/></svg> }
+                @case ('bug') { <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 7V3m8 4V3M3 13h18M5 7h14M6 19a6 6 0 0 0 12 0V9H6z"/></svg> }
+                @case ('team') { <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg> }
+                @case ('time') { <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> }
+              }
+            </div>
+          </div>
+          <div class="mt-3 text-2xl font-semibold">{{ s.value }}</div>
+          <div class="mt-1 text-xs"
+               [ngClass]="s.deltaDir === 'up' ? 'text-emerald-400' : 'text-rose-400'">
+            {{ s.deltaText }}
+          </div>
+        </div>
+      </article>
+    }
+  </section>
+
+  <!-- Bottom grid: Recent Activity + Performance -->
+  <section class="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6 pb-10">
+    <!-- Recent Activity -->
+    <article class="rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,0.02) inset">
+      <header class="px-5 pt-5 pb-3">
+        <h2 class="text-xl font-semibold">Recent Activity</h2>
+      </header>
+      <ul class="divide-y divide-white/10">
+        @for (a of activities; track a.id) {
+          <li class="px-5 py-3 hover:bg-white/[0.04] transition-colors">
+            <div class="flex items-center gap-3">
+              <div class="flex-1">
+                <div class="text-sm font-medium">{{ a.title }}</div>
+                <div class="text-xs text-gray-400">{{ a.project }}</div>
+              </div>
+              <span class="rounded-full px-2 py-0.5 text-[11px]"
+                    [ngClass]="a.status==='Active' ? 'bg-emerald-500/20 text-emerald-300' : 'bg-rose-500/20 text-rose-300'">
+                {{ a.status }}
+              </span>
+            </div>
+          </li>
         }
-      </div>
-    </div>
+      </ul>
+    </article>
 
-    <!-- Summary cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      @for (s of summary(); track s.label) {
-        <div class="bg-white rounded-xl shadow-md p-5">
-          <div class="text-sm" style="color:$muted-text-color;">{{ s.label }}</div>
-          <div class="mt-1 text-2xl font-semibold text-gray-900">{{ s.value }}</div>
-        </div>
-      }
-    </div>
+    <!-- Project Performance -->
+    <article class="rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,0.02) inset">
+      <header class="px-5 pt-5 pb-3">
+        <h2 class="text-xl font-semibold">Project Performance</h2>
+      </header>
 
-    <!-- Two columns -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <!-- Recent runs -->
-      <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-          <div>
-            <h2 class="text-lg font-semibold" style="color:$text-main-color;">Recent runs</h2>
-            <p class="text-sm" style="color:$muted-text-color;">Latest pipeline activity</p>
+      <div class="px-5 pb-5 space-y-6">
+        <!-- Success Rate -->
+        <div>
+          <div class="flex items-center justify-between text-sm">
+            <span>Success Rate</span><span>{{ performance.successRate }}%</span>
           </div>
-          <div class="relative">
-            <input
-              [ngModel]="query()"
-              (ngModelChange)="query.set($event)"
-              placeholder="Search…"
-              class="w-56 border border-gray-200 rounded-md px-3 py-2 pl-9 bg-white"
-            />
-            <svg class="w-4 h-4 absolute left-3 top-2.5 text-gray-400" viewBox="0 0 24 24" fill="none">
-              <path
-                d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28.79.79L20 20.5 21.5 19l-6-6z"
-                fill="currentColor"
-              />
-            </svg>
+          <div class="mt-2 h-2 rounded bg-white/10">
+            <div class="h-2 rounded bg-emerald-500"
+                 [style.width.%]="performance.successRate"></div>
           </div>
         </div>
-        <div class="divide-y divide-gray-100">
-          @if (filteredRuns().length) {
-            @for (r of filteredRuns(); track r.id) {
-              <div class="px-6 py-4 flex items-center gap-3 hover:bg-gray-50">
-                <div class="flex-1">
-                  <div class="text-gray-900 font-medium">#{{ r.id }} · {{ r.pipeline }}</div>
-                  <div class="text-sm" style="color:$muted-text-color;">{{ r.when }}</div>
-                </div>
-                <div>
-                  @if (r.status === 'running') {
-                    <span class="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-700">Running</span>
-                  }
-                  @if (r.status === 'success') {
-                    <span class="text-xs px-2 py-0.5 rounded-full bg-green-50 text-green-700">Success</span>
-                  }
-                  @if (r.status === 'failed') {
-                    <span class="text-xs px-2 py-0.5 rounded-full bg-red-50 text-red-700">Failed</span>
-                  }
-                </div>
-                <button (click)="openRun(r.id)" class="text-sm text-blue-600 hover:underline">Details</button>
-              </div>
-            }
-          } @else {
-            <div class="px-6 py-6 text-sm" style="color:$muted-text-color;">No runs yet.</div>
-          }
-        </div>
-      </section>
 
-      <!-- Recent projects -->
-      <section class="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <div class="px-6 py-4 border-b border-gray-200">
-          <h2 class="text-lg font-semibold" style="color:$text-main-color;">Recent projects</h2>
-          <p class="text-sm" style="color:$muted-text-color;">Quick access</p>
+        <!-- Avg Duration -->
+        <div>
+          <div class="flex items-center justify-between text-sm">
+            <span>Avg Duration</span><span>{{ performance.avgDurationText }}</span>
+          </div>
+          <div class="mt-2 h-2 rounded bg-white/10">
+            <div class="h-2 rounded bg-blue-500"
+                 [style.width.%]="performance.avgDuration"></div>
+          </div>
         </div>
-        <div class="divide-y divide-gray-100">
-          @if (recentProjects().length) {
-            @for (p of recentProjects(); track p.id) {
-              <div class="px-6 py-4 flex items-center justify-between hover:bg-gray-50">
-                <div>
-                  <div class="text-gray-900 font-medium">{{ p.name }}</div>
-                  @if (p.updatedAt) {
-                    <div class="text-sm" style="color:$muted-text-color;">Updated {{ p.updatedAt }}</div>
-                  }
-                </div>
-                <button (click)="openProject(p.id)" class="text-sm text-blue-600 hover:underline">
-                  Open
-                </button>
-              </div>
-            }
-          } @else {
-            <div class="px-6 py-6 text-sm" style="color:$muted-text-color;">No projects yet.</div>
-          }
-        </div>
-      </section>
-    </div>
 
-    <!-- (optional) Placeholder under graph/statistics -->
-    <section class="bg-white border border-gray-200 rounded-lg p-6">
-      <h2 class="text-lg font-semibold mb-2" style="color:$text-main-color;">Activity</h2>
-      <div
-        class="h-48 bg-gray-50 border border-dashed border-gray-200 rounded-md grid place-items-center text-sm"
-        style="color:$gray-color;"
-      >
-        Chart placeholder · TODO: integrate charts
+        <!-- Queue Time -->
+        <div>
+          <div class="flex items-center justify-between text-sm">
+            <span>Queue Time</span><span>{{ performance.queueTimeText }}</span>
+          </div>
+          <div class="mt-2 h-2 rounded bg-white/10">
+            <div class="h-2 rounded bg-amber-500"
+                 [style.width.%]="performance.queueTime"></div>
+          </div>
+        </div>
       </div>
-    </section>
-  </div>
+    </article>
+  </section>
 </div>

--- a/frontend/admin/src/app/pages/dashboard/dashboard.component.scss
+++ b/frontend/admin/src/app/pages/dashboard/dashboard.component.scss
@@ -1,7 +1,1 @@
-@use 'styles/variables' as *;
-
-:host {
-  display: block;
-}
-
-/* additional local styles if needed */
+:host { display:block; }

--- a/frontend/admin/src/app/pages/dashboard/dashboard.component.ts
+++ b/frontend/admin/src/app/pages/dashboard/dashboard.component.ts
@@ -1,65 +1,51 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router, RouterModule } from '@angular/router';
-import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+type Stat = {
+  id: string;
+  title: string;
+  value: string | number;
+  deltaText: string;        // "+12% from last month"
+  deltaDir: 'up'|'down';    // влияет на цвет
+  icon: 'trend'|'activity'|'code'|'bug'|'team'|'time';
+};
+type Activity = {
+  id: string; title: string; project: string; status: 'Active'|'Inactive';
+};
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DashboardComponent {
-  private readonly router = inject(Router);
+  stats: Stat[] = [
+    { id:'total',    title:'Total Projects',  value:4,   deltaText:'+12% from last month', deltaDir:'up',   icon:'trend' },
+    { id:'pipelines',title:'Active Pipelines',value:7,   deltaText:'+8% from last month',  deltaDir:'up',   icon:'activity' },
+    { id:'loc',      title:'Lines of Code',   value:'2.4M', deltaText:'+15% from last month', deltaDir:'up', icon:'code' },
+    { id:'bugs',     title:'Bugs Solved',     value:142, deltaText:'-5% from last month',  deltaDir:'down', icon:'bug' },
+    { id:'team',     title:'Team Members',    value:24,  deltaText:'+2 from last month',   deltaDir:'up',   icon:'team' },
+    { id:'runtime',  title:'Avg Runtime',     value:'3.2m', deltaText:'-12% from last month', deltaDir:'down', icon:'time' },
+  ];
 
-  summary = signal([
-    { label: 'Projects', value: 0 },
-    { label: 'Pipelines', value: 0 },
-    { label: 'Runs', value: 0 },
-    { label: 'Failures', value: 0 },
-  ]);
+  activities: Activity[] = [
+    { id:'a1', title:'Main Pipeline (main branch)', project:'AI Review Platform', status:'Active' },
+    { id:'a2', title:'Log Analysis (staging)',      project:'AI Review Platform', status:'Inactive' },
+    { id:'a3', title:'Daily Sales Report',          project:'E-commerce Analytics', status:'Active' },
+    { id:'a4', title:'Customer Segmentation',       project:'E-commerce Analytics', status:'Active' },
+    { id:'a5', title:'API Deployment',              project:'Mobile App Backend', status:'Active' },
+    { id:'a6', title:'Database Migration',          project:'Mobile App Backend', status:'Inactive' },
+  ];
 
-  quick = signal([
-    { id: 'new-project', label: 'New Project', icon: 'plus', to: '/create-project' },
-    { id: 'pipelines', label: 'Pipelines', icon: 'pipeline', to: '/all-pipelines' },
-  ]);
-
-  recentRuns = signal<
-    { id: string; pipeline: string; status: 'success' | 'failed' | 'running'; when: string }[]
-  >([]);
-  recentProjects = signal<
-    { id: string; name: string; updatedAt?: string }[]
-  >([]);
-
-  query = signal('');
-  filteredRuns = computed(() => {
-    const q = this.query().toLowerCase();
-    return this.recentRuns().filter(r =>
-      !q || r.id.includes(q) || r.pipeline.toLowerCase().includes(q)
-    );
-  });
-
-  go(to: string) {
-    this.router.navigateByUrl(to);
-  }
-
-  openProject(id: string) {
-    this.router.navigate(['project-detail', id]);
-  }
-
-  openRun(id: string) {
-    // TODO: /runs/:id
-    this.router.navigate(['/runs', id]);
-  }
-
-  // TODO: load data from API
-  // TODO: i18n
+  performance = {
+    successRate: 94.2,   // %
+    avgDuration: 72,     // % длины полосы (визуальная метрика)
+    queueTime: 35,       // %
+    avgDurationText: '3.2 minutes',
+    queueTimeText: '12 seconds',
+  };
 }


### PR DESCRIPTION
## Summary
- replace dashboard page with standalone component featuring KPI cards, recent activity list, and performance bars styled with Tailwind CSS

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b864b44b948321bd93dbabbf784cfe