### PR TITLE
feat(projects): project details page + routes wiring, card links

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -7,12 +7,26 @@ export const routes: Routes = [
     children: [
       { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
       { path: 'dashboard', loadComponent: () => import('./pages/dashboard/dashboard.component').then(m => m.DashboardComponent) },
-      { path: 'projects', loadComponent: () => import('./pages/projects/projects.component').then(m => m.ProjectsComponent) },
-      { path: 'projects/new', loadComponent: () => import('./pages/project-create/project-create.component').then(m => m.ProjectCreateComponent) },
-      { path: 'project-detail/:id', loadComponent: () => import('./pages/project-detail/project-detail.component').then(m => m.ProjectDetailComponent) },
-      { path: 'all-pipelines', loadComponent: () => import('./pages/all-pipelines/all-pipelines.component').then(m => m.AllPipelinesComponent) },
-      { path: 'pipeline-detail/:id', loadComponent: () => import('./pages/pipeline-detail/pipeline-detail.component').then(m => m.PipelineDetailComponent) },
-      { path: 'create-project', loadComponent: () => import('./pages/create-project/create-project.component').then(m => m.CreateProjectComponent) },
+      {
+        path: 'projects',
+        loadComponent: () => import('./pages/projects/projects.component').then(m => m.ProjectsComponent),
+      },
+      {
+        path: 'projects/new',
+        loadComponent: () => import('./pages/project-create/project-create.component').then(m => m.ProjectCreateComponent),
+      },
+      {
+        path: 'projects/:id',
+        loadComponent: () => import('./pages/project-details/project-details.component').then(m => m.ProjectDetailsComponent),
+      },
+      {
+        path: 'all-pipelines',
+        loadComponent: () => import('./pages/all-pipelines/all-pipelines.component').then(m => m.AllPipelinesComponent),
+      },
+      {
+        path: 'pipeline-detail/:id',
+        loadComponent: () => import('./pages/pipeline-detail/pipeline-detail.component').then(m => m.PipelineDetailComponent),
+      },
       { path: 'runs', loadComponent: () => import('./pages/runs/runs.component').then(m => m.RunsComponent) },
       { path: 'dashboard-stats', loadComponent: () => import('./pages/dashboard-stats/dashboard-stats.component').then(m => m.DashboardStatsComponent) },
       { path: 'settings', loadComponent: () => import('./pages/settings/settings.component').then(m => m.SettingsComponent) },

--- a/frontend/admin/src/app/layout/sidebar/sidebar.component.html
+++ b/frontend/admin/src/app/layout/sidebar/sidebar.component.html
@@ -8,7 +8,7 @@
 
   <nav class="px-2 space-y-2">
     @for (it of items; track it.id) {
-      <a [routerLink]="[it.to]" routerLinkActive="is-active" [routerLinkActiveOptions]="{ exact: true }"
+      <a [routerLink]="[it.to]" routerLinkActive="is-active"
          class="flex items-center gap-3 rounded-md px-3 py-2 text-sm text-gray-300 hover:bg-white/5 hover:text-white">
         <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           @switch (it.icon) {

--- a/frontend/admin/src/app/pages/project-details/project-details.component.html
+++ b/frontend/admin/src/app/pages/project-details/project-details.component.html
@@ -1,0 +1,67 @@
+<div class="w-full mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="pt-6">
+    <a [routerLink]="['/projects']" class="inline-flex items-center gap-2 text-gray-300 hover:text-white">
+      <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+      Back to Projects
+    </a>
+    <h1 class="mt-2 text-3xl font-bold">{{ project.name }}</h1>
+    <p class="text-sm text-gray-400">{{ project.description }}</p>
+  </div>
+
+  <div class="mt-6 flex items-center justify-end">
+    <button class="inline-flex items-center gap-2 h-10 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium">
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+      Create Pipeline
+    </button>
+  </div>
+
+  <section class="mt-3 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+    <header class="px-4 sm:px-5 pt-4 pb-3 border-b border-white/10">
+      <h2 class="text-lg font-semibold">Project Pipelines</h2>
+      <p class="text-sm text-gray-400">No pipelines created yet. Create your first pipeline to get started with automated workflows.</p>
+    </header>
+
+    <div class="overflow-x-auto">
+      <table class="min-w-full table-auto">
+        <thead class="text-left text-xs uppercase tracking-wide text-gray-400">
+          <tr>
+            <th class="px-4 py-3 w-8"></th>
+            <th class="px-4 py-3">Pipeline</th>
+            <th class="px-4 py-3">Status</th>
+            <th class="px-4 py-3 whitespace-nowrap">Last Run</th>
+            <th class="px-4 py-3">Actions</th>
+          </tr>
+          <tr><td colspan="5" class="border-b border-white/10"></td></tr>
+        </thead>
+        <tbody>
+          @for (r of project.pipelines; track r.id) {
+            <tr class="border-t border-white/10 hover:bg-white/[0.04]">
+              <td class="px-4 py-3">
+                <svg class="w-3.5 h-3.5 text-gray-300" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+              </td>
+              <td class="px-4 py-3 text-sm font-medium text-gray-200">{{ r.name }}</td>
+              <td class="px-4 py-3">
+                <span class="rounded-full px-2 py-0.5 text-[11px]"
+                      [ngClass]="r.status==='Active' ? 'bg-emerald-500/20 text-emerald-300' : 'bg-rose-500/20 text-rose-300'">
+                  {{ r.status }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-300 whitespace-nowrap">
+                <span class="inline-flex items-center gap-2">
+                  <svg class="w-4 h-4 text-gray-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                  {{ r.lastRun | date:'MM/dd/yyyy, hh:mm a' }}
+                </span>
+              </td>
+              <td class="px-4 py-3 text-sm">
+                <a [routerLink]="['/pipelines', r.id]" class="text-blue-400 hover:underline">View Details</a>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="h-10"></div>
+</div>
+

--- a/frontend/admin/src/app/pages/project-details/project-details.component.scss
+++ b/frontend/admin/src/app/pages/project-details/project-details.component.scss
@@ -1,0 +1,2 @@
+:host { display: block; }
+

--- a/frontend/admin/src/app/pages/project-details/project-details.component.ts
+++ b/frontend/admin/src/app/pages/project-details/project-details.component.ts
@@ -1,0 +1,33 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+
+type Status = 'Active' | 'Inactive';
+type PipelineRow = { id: string; name: string; status: Status; lastRun: string };
+
+@Component({
+  selector: 'app-project-details',
+  standalone: true,
+  imports: [CommonModule, RouterModule, DatePipe],
+  templateUrl: './project-details.component.html',
+  styleUrls: ['./project-details.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectDetailsComponent {
+  private route = inject(ActivatedRoute);
+  readonly id = this.route.snapshot.paramMap.get('id') ?? 'unknown';
+
+  // мок-данные (замени на сервис)
+  readonly project = {
+    id: this.id,
+    name: this.id === 'ai-review' ? 'AI Review Platform' : 'Project ' + this.id,
+    description:
+      'Core company product for automated code reviews with machine learning capabilities',
+    pipelines: <PipelineRow[]>[
+      { id: 'p-main', name: 'Main Pipeline (main branch)', status: 'Active', lastRun: '2024-01-15T14:30:00Z' },
+      { id: 'p-log', name: 'Log Analysis (staging)', status: 'Inactive', lastRun: '2024-01-14T11:00:00Z' },
+      { id: 'p-perf', name: 'Performance Testing', status: 'Active', lastRun: '2024-01-15T09:15:00Z' },
+    ],
+  };
+}
+

--- a/frontend/admin/src/app/pages/projects/projects.component.html
+++ b/frontend/admin/src/app/pages/projects/projects.component.html
@@ -34,7 +34,7 @@
               >
                 <path d="M3 7V5a2 2 0 0 1 2-2h5l2 2h9v14H3Z" />
               </svg>
-              <h2 class="text-lg font-semibold">{{ p.name }}</h2>
+              <a [routerLink]="['/projects', p.id]" class="text-lg font-semibold hover:underline">{{ p.name }}</a>
             </div>
             <span class="rounded-full border border-white/10 px-2 py-0.5 text-[11px] bg-white/10"
               >{{ p.provider }}</span


### PR DESCRIPTION
## Summary
- add project details page displaying pipelines
- wire projects routes for list, creation, and details
- link project cards to detail view and update sidebar active state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b9890a1c8321a31412ce35b6fc07