### PR TITLE
feat(pipelines): modal create wizard and pipeline details

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -9,9 +9,21 @@ export const routes: Routes = [
       { path: 'dashboard', loadComponent: () => import('./pages/dashboard/dashboard.component').then(m => m.DashboardComponent) },
       { path: 'projects', loadComponent: () => import('./pages/projects/projects.component').then(m => m.ProjectsComponent) },
       { path: 'projects/new', loadComponent: () => import('./pages/project-create/project-create.component').then(m => m.ProjectCreateComponent) },
-      { path: 'projects/:projectId/pipelines/new', loadComponent: () => import('./pages/pipeline-create/pipeline-create.component').then(m => m.PipelineCreateComponent) },
+
+      // Modal pipeline creation
+      {
+        path: 'projects/:projectId/pipelines/new',
+        outlet: 'modal',
+        loadComponent: () =>
+          import('./pages/pipeline-create-modal/pipeline-create-modal.component').then(
+            m => m.PipelineCreateModalComponent
+          ),
+      },
+
       { path: 'projects/:id', loadComponent: () => import('./pages/project-details/project-details.component').then(m => m.ProjectDetailsComponent) },
-      { path: 'pipelines/:id', loadComponent: () => import('./pages/pipeline-details/pipeline-details.component').then(m => m.PipelineDetailsComponent), data: { stub: true } },
+
+      // Pipeline details
+      { path: 'pipelines/:id', loadComponent: () => import('./pages/pipeline-details/pipeline-details.component').then(m => m.PipelineDetailsComponent) },
       { path: 'all-pipelines', loadComponent: () => import('./pages/all-pipelines/all-pipelines.component').then(m => m.AllPipelinesComponent) },
       { path: 'runs', loadComponent: () => import('./pages/runs/runs.component').then(m => m.RunsComponent) },
       { path: 'dashboard-stats', loadComponent: () => import('./pages/dashboard-stats/dashboard-stats.component').then(m => m.DashboardStatsComponent) },

--- a/frontend/admin/src/app/layout/app-layout.component.html
+++ b/frontend/admin/src/app/layout/app-layout.component.html
@@ -91,4 +91,7 @@
       <router-outlet></router-outlet>
     </main>
   </div>
+
+  <!-- Modal outlet -->
+  <router-outlet name="modal"></router-outlet>
 </div>

--- a/frontend/admin/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.html
+++ b/frontend/admin/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.html
@@ -1,0 +1,115 @@
+<div class="fixed inset-0 z-40" style="background:rgba(0,0,0,.65)" (click)="close()"></div>
+<div class="fixed inset-0 z-50 grid place-items-center p-4">
+  <div class="w-full max-w-3xl rounded-xl border border-white/10 bg-[#15181c]" style="box-shadow:0 0 0 1px rgba(255,255,255,.04) inset" (click)="$event.stopPropagation()">
+    <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">
+      <h2 class="text-lg font-semibold">Create Pipeline @if (projectId) { <span>for Project {{ projectId }}</span> }</h2>
+      <button class="h-8 w-8 rounded-md hover:bg-white/5" (click)="close()" aria-label="Close">✕</button>
+    </div>
+
+    <div class="px-6 py-4">
+      <div class="flex items-center justify-center gap-4">
+        @for (s of [1,2,3,4]; track s) {
+          <div class="flex items-center">
+            <div class="w-8 h-8 rounded-full flex items-center justify-center text-sm" [ngClass]="step >= s ? 'bg-blue-600 text-white' : 'bg-white/5 text-gray-400'">{{ s }}</div>
+            @if (s < 4) {
+              <div class="w-8 h-0.5" [ngClass]="step > s ? 'bg-blue-600' : 'bg-white/10'"></div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+
+    <form [formGroup]="form" class="px-6 pb-6">
+      @if (step === 1) {
+        <div class="space-y-3">
+          <label class="block text-sm font-medium text-gray-200">Pipeline Name</label>
+          <input type="text" formControlName="name" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-600/40" placeholder="My Pipeline" />
+        </div>
+      }
+
+      @if (step === 2) {
+        <div class="space-y-4">
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            @for (opt of ['manual','push','schedule']; track opt) {
+              <label class="cursor-pointer">
+                <input type="radio" class="sr-only" formControlName="trigger" [value]="opt" />
+                <div class="rounded-lg border p-4 text-sm" [ngClass]="form.value.trigger===opt ? 'bg-blue-600/20 border-blue-600/40 text-white' : 'bg-white/[0.02] border-white/10 text-gray-300'">
+                  <div class="font-medium capitalize">{{ opt }}</div>
+                  @if (opt === 'manual') { <div class="text-xs text-gray-400">Run on demand</div> }
+                  @if (opt === 'push') { <div class="text-xs text-gray-400">On git push</div> }
+                  @if (opt === 'schedule') { <div class="text-xs text-gray-400">On schedule</div> }
+                </div>
+              </label>
+            }
+          </div>
+
+          @if (form.value.trigger === 'push') {
+            <div class="space-y-1">
+              <label class="block text-sm font-medium text-gray-200">Branch</label>
+              <input type="text" formControlName="branch" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-600/40" />
+            </div>
+          }
+
+          @if (form.value.trigger === 'schedule') {
+            <div [formGroup]="form.get('schedule')" class="grid gap-3 sm:grid-cols-2">
+              <div class="space-y-1">
+                <label class="block text-sm font-medium text-gray-200">Type</label>
+                <select formControlName="type" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none">
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="cron">Cron</option>
+                </select>
+              </div>
+              @if (form.get('schedule')?.value?.type === 'cron') {
+                <div class="space-y-1 sm:col-span-1">
+                  <label class="block text-sm font-medium text-gray-200">Cron</label>
+                  <input formControlName="cron" placeholder="0 0 * * *" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-600/40" />
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+
+      @if (step === 3) {
+        <div class="space-y-4">
+          <p class="text-sm font-medium text-gray-200">AI Agents & Rules</p>
+          <div class="space-y-2">
+            @for (a of agentOptions; let i = index; track a) {
+              <label class="flex items-center gap-2 text-sm">
+                <input type="checkbox" [formControl]="agentsArray.at(i)" class="h-4 w-4 rounded border-white/10 bg-white/5" />
+                {{ a }}
+              </label>
+            }
+          </div>
+          <div class="space-y-1">
+            <label class="block text-sm font-medium text-gray-200">Rule / Note</label>
+            <input type="text" formControlName="rule" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-600/40" placeholder="e.g. notify on failure" />
+          </div>
+        </div>
+      }
+
+      @if (step === 4) {
+        <div class="space-y-2 text-sm text-gray-300">
+          <p><span class="text-gray-400">Name:</span> {{ form.value.name }}</p>
+          <p><span class="text-gray-400">Trigger:</span> {{ form.value.trigger }}</p>
+          @if (form.value.trigger === 'push') { <p><span class="text-gray-400">Branch:</span> {{ form.value.branch }}</p> }
+          @if (form.value.trigger === 'schedule') {
+            <p><span class="text-gray-400">Schedule:</span> {{ form.value.schedule.type }} @if (form.value.schedule.type === 'cron') { ({{ form.value.schedule.cron }}) }</p>
+          }
+          @if (selectedAgents().length) { <p><span class="text-gray-400">Agents:</span> {{ selectedAgents().join(', ') }}</p> }
+          @if (form.value.rule) { <p><span class="text-gray-400">Rule:</span> {{ form.value.rule }}</p> }
+        </div>
+      }
+    </form>
+
+    <div class="flex items-center justify-between px-6 py-4 border-t border-white/10">
+      <button class="h-10 px-4 rounded-md bg-white/5 hover:bg-white/10 text-sm" (click)="step === 1 ? close() : prev()">
+        {{ step === 1 ? 'Cancel' : 'Previous' }}
+      </button>
+      <button class="h-10 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium" [disabled]="step !== 4 && !canNext(step)" (click)="step === 4 ? create() : next()">
+        {{ step === 4 ? 'Create' : 'Next' }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/admin/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.scss
+++ b/frontend/admin/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.scss
@@ -1,0 +1,1 @@
+:host { display: block; }

--- a/frontend/admin/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.ts
+++ b/frontend/admin/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.ts
@@ -1,0 +1,79 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-pipeline-create-modal',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './pipeline-create-modal.component.html',
+  styleUrls: ['./pipeline-create-modal.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PipelineCreateModalComponent {
+  step: 1 | 2 | 3 | 4 = 1;
+  projectId = this.route.snapshot.paramMap.get('projectId') || '';
+
+  agentOptions = ['Static Analysis', 'Security Scan', 'Lint/Format'];
+
+  form: FormGroup = this.fb.group({
+    name: ['', [Validators.required, Validators.minLength(3)]],
+    trigger: this.fb.control<'manual' | 'push' | 'schedule'>('manual'),
+    branch: this.fb.control('main'),
+    schedule: this.fb.group({
+      type: this.fb.control<'daily' | 'weekly' | 'cron'>('daily'),
+      cron: [''],
+    }),
+    agents: this.fb.array(this.agentOptions.map(() => this.fb.control(false))),
+    rule: [''],
+  });
+
+  constructor(private fb: FormBuilder, private router: Router, private route: ActivatedRoute) {}
+
+  get agentsArray(): FormArray {
+    return this.form.get('agents') as FormArray;
+  }
+
+  selectedAgents(): string[] {
+    return this.agentOptions.filter((_, i) => this.agentsArray.at(i).value);
+  }
+
+  next() {
+    if (this.step < 4) {
+      this.step++;
+    }
+  }
+
+  prev() {
+    if (this.step > 1) {
+      this.step--;
+    }
+  }
+
+  close() {
+    this.router.navigate([{ outlets: { modal: null } }]);
+  }
+
+  canNext(step: number): boolean {
+    if (step === 1) {
+      return this.form.get('name')!.valid;
+    }
+    if (step === 2) {
+      if (this.form.value.trigger === 'schedule' && this.form.value.schedule?.type === 'cron') {
+        return !!this.form.value.schedule?.cron?.trim();
+      }
+      return true;
+    }
+    return true;
+  }
+
+  create() {
+    const payload = this.form.value;
+    console.log('CREATE PIPELINE', payload);
+    this.close();
+    if (this.projectId) {
+      this.router.navigate(['/projects', this.projectId]);
+    }
+  }
+}

--- a/frontend/admin/src/app/pages/pipeline-details/pipeline-details.component.html
+++ b/frontend/admin/src/app/pages/pipeline-details/pipeline-details.component.html
@@ -1,1 +1,145 @@
-<div class="p-4">Pipeline details works!</div>
+<div class="w-full mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="pt-6">
+    <a routerLink="/all-pipelines" class="inline-flex items-center gap-2 text-gray-300 hover:text-white">
+      <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+      Back to Pipelines
+    </a>
+    <div class="mt-4 flex items-center justify-between">
+      <div>
+        <h1 class="text-3xl font-bold flex items-center gap-2">
+          {{ pipeline.name }}
+          <span class="rounded-full px-2 py-0.5 text-[11px]" [ngClass]="pipeline.status==='Active' ? 'bg-emerald-500/20 text-emerald-300' : 'bg-rose-500/20 text-rose-300'">{{ pipeline.status }}</span>
+        </h1>
+        <p class="text-sm text-gray-400">{{ pipeline.project }} • Trigger: {{ pipeline.trigger }}</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <button class="h-9 px-4 rounded-md border border-white/10 bg-white/5 text-sm hover:bg-white/10">⚙ Configure</button>
+        <button (click)="run()" class="h-9 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium flex items-center gap-1">
+          <span>▶</span> Run Pipeline
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+    <div class="p-4 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <p class="text-sm text-gray-400">Last Run</p>
+      <p class="mt-1 text-xl font-semibold">{{ pipeline.lastRun | date:'MM/dd/yyyy, hh:mm a' }}</p>
+    </div>
+    <div class="p-4 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <p class="text-sm text-gray-400">Success Rate</p>
+      <p class="mt-1 text-xl font-semibold text-emerald-400">{{ pipeline.stats.successRate }}%</p>
+      <p class="text-xs text-gray-400">Last 30 days</p>
+    </div>
+    <div class="p-4 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <p class="text-sm text-gray-400">Avg Duration</p>
+      <p class="mt-1 text-xl font-semibold">{{ (pipeline.stats.avgDurationSec / 60) | number:'1.0-0' }}m {{ (pipeline.stats.avgDurationSec % 60) | number:'1.0-0' }}s</p>
+    </div>
+    <div class="p-4 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <p class="text-sm text-gray-400">Total Runs</p>
+      <p class="mt-1 text-xl font-semibold">{{ pipeline.stats.totalRuns }}</p>
+      <p class="text-xs text-gray-400">All time</p>
+    </div>
+  </div>
+
+  <div class="mt-8 flex items-center gap-2">
+    <button (click)="setTab('overview')" class="px-3 py-1.5 rounded-full text-sm" [ngClass]="tab==='overview' ? 'bg-white/10 text-white' : 'bg-white/5 text-gray-300 hover:bg-white/10'">Overview</button>
+    <button (click)="setTab('history')" class="px-3 py-1.5 rounded-full text-sm" [ngClass]="tab==='history' ? 'bg-white/10 text-white' : 'bg-white/5 text-gray-300 hover:bg-white/10'">Run History</button>
+    <button (click)="setTab('agents')" class="px-3 py-1.5 rounded-full text-sm" [ngClass]="tab==='agents' ? 'bg-white/10 text-white' : 'bg-white/5 text-gray-300 hover:bg-white/10'">AI Agents</button>
+    <button (click)="setTab('settings')" class="px-3 py-1.5 rounded-full text-sm" [ngClass]="tab==='settings' ? 'bg-white/10 text-white' : 'bg-white/5 text-gray-300 hover:bg-white/10'">Settings</button>
+  </div>
+
+  @if (tab === 'overview') {
+    <section class="mt-6 rounded-xl border border-white/10 bg-white/[0.03] p-6" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <h2 class="text-lg font-semibold mb-4">Pipeline Overview</h2>
+      <div class="grid gap-6 md:grid-cols-2">
+        <div class="space-y-2 text-sm">
+          <p><span class="text-gray-400">Trigger:</span> {{ pipeline.overview.trigger }}</p>
+          <p><span class="text-gray-400">Status:</span> {{ pipeline.overview.status }}</p>
+          <p><span class="text-gray-400">Agents:</span> {{ pipeline.overview.agents }}</p>
+        </div>
+        <div class="space-y-4">
+          <div>
+            <div class="flex justify-between text-xs text-gray-400"><span>Success Rate</span><span>{{ pipeline.stats.successRate }}%</span></div>
+            <div class="h-2 bg-white/5 rounded mt-1">
+              <div class="h-full bg-emerald-500 rounded" [style.width.%]="pipeline.stats.successRate"></div>
+            </div>
+          </div>
+          <div>
+            <div class="flex justify-between text-xs text-gray-400"><span>Average Duration</span><span>{{ pipeline.stats.avgDurationSec }}s</span></div>
+            <div class="h-2 bg-white/5 rounded mt-1">
+              <div class="h-full bg-blue-500 rounded" [style.width.%]="(pipeline.stats.avgDurationSec/300)*100"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  }
+
+  @if (tab === 'history') {
+    <div class="mt-6 rounded-xl border border-white/10 bg-white/[0.03] overflow-x-auto" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <table class="min-w-full table-auto">
+        <thead class="text-left text-xs uppercase tracking-wide text-gray-400">
+          <tr>
+            <th class="px-4 py-3">Date</th>
+            <th class="px-4 py-3">Status</th>
+            <th class="px-4 py-3">Duration</th>
+            <th class="px-4 py-3">Commit</th>
+            <th class="px-4 py-3">Actions</th>
+          </tr>
+          <tr><td colspan="5" class="border-b border-white/10"></td></tr>
+        </thead>
+        <tbody>
+          @for (h of history; track h.date) {
+            <tr class="border-t border-white/10 hover:bg-white/[0.04]">
+              <td class="px-4 py-3 text-sm text-gray-300">{{ h.date | date:'MM/dd/yyyy, hh:mm a' }}</td>
+              <td class="px-4 py-3">
+                <span class="rounded-full px-2 py-0.5 text-[11px]" [ngClass]="h.status==='Success' ? 'bg-emerald-500/20 text-emerald-300' : 'bg-rose-500/20 text-rose-300'">{{ h.status }}</span>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-300">{{ h.duration }}s</td>
+              <td class="px-4 py-3 text-sm text-gray-300">{{ h.ref }}</td>
+              <td class="px-4 py-3 text-sm"><a class="text-blue-400 hover:underline">View Log</a></td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  }
+
+  @if (tab === 'agents') {
+    <div class="mt-6 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      @for (a of agents; track a.name) {
+        <div class="p-4 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+          <div class="flex items-center justify-between">
+            <span class="text-sm">{{ a.name }}</span>
+            <button (click)="a.active = !a.active" class="relative inline-flex h-5 w-9 items-center rounded-full" [ngClass]="a.active ? 'bg-blue-600' : 'bg-white/10'">
+              <span class="h-4 w-4 bg-white rounded-full transform transition" [ngClass]="a.active ? 'translate-x-4' : 'translate-x-0'"></span>
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  }
+
+  @if (tab === 'settings') {
+    <div class="mt-6 rounded-xl border border-white/10 bg-white/[0.03] p-6" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
+      <form class="space-y-4">
+        <div class="space-y-1">
+          <label class="block text-sm font-medium text-gray-200">Name</label>
+          <input #name type="text" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none" [value]="pipeline.name" />
+        </div>
+        <div class="space-y-1">
+          <label class="block text-sm font-medium text-gray-200">Trigger</label>
+          <input #trigger type="text" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none" [value]="pipeline.trigger" />
+        </div>
+        <div class="space-y-1">
+          <label class="block text-sm font-medium text-gray-200">Branch</label>
+          <input #branch type="text" class="h-11 w-full rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none" value="main" />
+        </div>
+        <button type="button" (click)="saveSettings(name.value, trigger.value, branch.value)" class="h-10 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium">Save</button>
+      </form>
+    </div>
+  }
+
+  <div class="h-10"></div>
+</div>

--- a/frontend/admin/src/app/pages/pipeline-details/pipeline-details.component.ts
+++ b/frontend/admin/src/app/pages/pipeline-details/pipeline-details.component.ts
@@ -1,12 +1,54 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
+import { ActivatedRoute, RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-pipeline-details',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule, DatePipe],
   templateUrl: './pipeline-details.component.html',
   styleUrls: ['./pipeline-details.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PipelineDetailsComponent {}
+export class PipelineDetailsComponent {
+  id = this.route.snapshot.paramMap.get('id') || '0';
+
+  pipeline = {
+    id: this.id,
+    name: 'Main Pipeline (main branch)',
+    status: 'Active',
+    project: 'AI Review Platform',
+    trigger: 'push to main',
+    lastRun: '2024-01-15T14:30:00Z',
+    stats: { successRate: 92, avgDurationSec: 204, totalRuns: 247 },
+    overview: { trigger: 'push to main', status: 'Active', agents: 45 },
+  };
+
+  tab: 'overview' | 'history' | 'agents' | 'settings' = 'overview';
+
+  history = [
+    { date: '2024-01-15T14:30:00Z', status: 'Success', duration: 180, ref: 'abc123' },
+    { date: '2024-01-14T13:00:00Z', status: 'Failed', duration: 210, ref: 'def456' },
+    { date: '2024-01-13T10:15:00Z', status: 'Success', duration: 200, ref: 'ghi789' },
+  ];
+
+  agents = [
+    { name: 'Static Analysis', active: true },
+    { name: 'Security Scan', active: true },
+    { name: 'Lint/Format', active: false },
+  ];
+
+  constructor(private route: ActivatedRoute) {}
+
+  setTab(t: 'overview' | 'history' | 'agents' | 'settings') {
+    this.tab = t;
+  }
+
+  run() {
+    console.log('RUN', this.pipeline.id);
+  }
+
+  saveSettings(name: string, trigger: string, branch: string) {
+    console.log('SAVE', { name, trigger, branch });
+  }
+}

--- a/frontend/admin/src/app/pages/project-details/project-details.component.html
+++ b/frontend/admin/src/app/pages/project-details/project-details.component.html
@@ -9,9 +9,10 @@
   </div>
 
     <div class="mt-6 flex items-center justify-end">
-      <a [routerLink]="['/projects', project.id, 'pipelines', 'new']"
+      <a [routerLink]="[{ outlets: { modal: ['projects', project.id, 'pipelines', 'new'] } }]"
          class="inline-flex items-center gap-2 h-10 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium">
-        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg> Create Pipeline
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+        Create Pipeline
       </a>
     </div>
 


### PR DESCRIPTION
## Summary
- add named modal outlet and route wiring for pipeline creation
- implement 4-step "Create Pipeline" modal wizard
- build pipeline details page with KPI cards, tabs, and mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8c0d82d008321b086733b1abc89d2