### PR TITLE
feat: add pipeline create modal and dark form styling

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -30,6 +30,7 @@ export const routes: Routes = [
             m => m.CreateProjectComponent,
           ),
       },
+      // Modal via named outlet (must stay between /projects/new and /projects/:id)
       {
         path: 'projects/:projectId/pipelines/new',
         outlet: 'modal',

--- a/frontend/admin/src/app/layout/app-layout.component.html
+++ b/frontend/admin/src/app/layout/app-layout.component.html
@@ -88,6 +88,7 @@
     <app-header (menuToggle)="toggleSidebar()"></app-header>
     <main class="p-4 sm:p-6">
       <router-outlet></router-outlet>
+      <!-- Named outlet for modal dialogs -->
       <router-outlet name="modal"></router-outlet>
     </main>
   </div>

--- a/frontend/admin/src/app/pages/create-project/create-project.component.html
+++ b/frontend/admin/src/app/pages/create-project/create-project.component.html
@@ -1,44 +1,43 @@
 <div class="w-full mx-auto px-4 sm:px-6 lg:px-8">
   <div class="pt-8 flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold page-title">Create Project</h1>
-    <button type="button" (click)="cancel()" class="text-sm text-gray-600 hover:text-gray-900">Cancel</button>
+    <button type="button" (click)="cancel()" class="text-sm text-gray-300 hover:text-white">Cancel</button>
   </div>
 
-  <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-6">
+  <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-6 rounded-xl border border-white/10 bg-white/[0.03] p-6" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">
       <!-- Name -->
       <div>
-        <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+        <label for="name" class="text-sm text-gray-300">Name</label>
         <input
           id="name"
           type="text"
           formControlName="name"
-          class="mt-1 w-full border border-gray-200 rounded-md px-3 py-2 bg-white"
+          class="mt-1 w-full h-11 rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-white/20"
           placeholder="my-project"
         />
         @if (form.get('name')?.touched && form.get('name')?.invalid) {
-          <p class="mt-1 text-xs text-red-600">Name is required.</p>
+          <p class="mt-1 text-xs text-red-400">Name is required.</p>
         }
       </div>
 
       <!-- Description -->
       <div>
-        <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
+        <label for="description" class="text-sm text-gray-300">Description</label>
         <textarea
           id="description"
-          rows="3"
           formControlName="description"
-          class="mt-1 w-full border border-gray-200 rounded-md px-3 py-2 bg-white"
+          class="mt-1 w-full min-h-[120px] rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-gray-100 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-white/20"
         ></textarea>
       </div>
 
       <!-- Repository / Git URL -->
       <div>
-        <label for="repo" class="block text-sm font-medium text-gray-700">Repository (Git URL)</label>
+        <label for="repo" class="text-sm text-gray-300">Repository (Git URL)</label>
         <input
           id="repo"
           type="text"
           formControlName="repository"
-          class="mt-1 w-full border border-gray-200 rounded-md px-3 py-2 bg-white"
+          class="mt-1 w-full h-11 rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-white/20"
           placeholder="https://github.com/org/repo.git"
         />
       </div>
@@ -46,21 +45,21 @@
       <!-- Default Branch & Visibility -->
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
-          <label for="branch" class="block text-sm font-medium text-gray-700">Default branch</label>
+          <label for="branch" class="text-sm text-gray-300">Default branch</label>
           <input
             id="branch"
             type="text"
             formControlName="defaultBranch"
-            class="mt-1 w-full border border-gray-200 rounded-md px-3 py-2 bg-white"
+            class="mt-1 w-full h-11 rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-white/20"
             placeholder="main"
           />
         </div>
         <div>
-          <label for="visibility" class="block text-sm font-medium text-gray-700">Visibility</label>
+          <label for="visibility" class="text-sm text-gray-300">Visibility</label>
           <select
             id="visibility"
             formControlName="visibility"
-            class="mt-1 w-full border border-white/10 rounded-md px-3 py-2 bg-white/5 text-gray-100"
+            class="mt-1 w-full h-11 rounded-md border border-white/10 bg-white/5 px-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-white/20"
           >
             <option value="private">Private</option>
             <option value="public">Public</option>
@@ -69,18 +68,18 @@
       </div>
 
       <!-- Footer -->
-      <div class="flex items-center justify-end gap-3">
+      <div class="flex items-center justify-end gap-3 pt-4">
         <button
           type="button"
           (click)="cancel()"
-          class="px-4 py-2 rounded-full border border-gray-200 bg-white hover:bg-gray-50"
+          class="h-10 px-4 rounded-md border border-white/10 bg-white/5 text-sm text-gray-100"
         >
           Cancel
         </button>
         <button
           type="submit"
           [disabled]="form.invalid || form.pending"
-          class="inline-flex items-center gap-2 rounded-full px-4 py-2 bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+          class="inline-flex items-center gap-2 h-10 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-60"
         >
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none">
             <path d="M5 12h14M12 5v14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />

--- a/frontend/admin/src/app/pages/project-detail/project-detail.component.html
+++ b/frontend/admin/src/app/pages/project-detail/project-detail.component.html
@@ -9,12 +9,15 @@
   </div>
 
     <div class="mt-6 flex items-center justify-end">
-      <a
-        [routerLink]="[{ outlets: { modal: ['projects', project.id, 'pipelines', 'new'] } }]"
+      <button
+        type="button"
+        (click)="openCreatePipelineModal(project.id)"
         class="inline-flex items-center gap-2 h-10 px-4 rounded-md bg-blue-600/90 hover:bg-blue-600 text-white text-sm font-medium">
-        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 5v14M5 12h14"/>
+        </svg>
         Create Pipeline
-      </a>
+      </button>
     </div>
 
   <section class="mt-3 rounded-xl border border-white/10 bg-white/[0.03]" style="box-shadow:0 0 0 1px rgba(255,255,255,.02) inset">

--- a/frontend/admin/src/app/pages/project-detail/project-detail.component.ts
+++ b/frontend/admin/src/app/pages/project-detail/project-detail.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
-import { ActivatedRoute, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 type Status = 'Active' | 'Inactive';
 type PipelineRow = { id: string; name: string; status: Status; lastRun: string };
@@ -14,20 +14,35 @@ type PipelineRow = { id: string; name: string; status: Status; lastRun: string }
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProjectDetailComponent {
-  private route = inject(ActivatedRoute);
-  readonly idFromRoute = this.route.snapshot.paramMap.get('id') ?? '';
-
-  // мок-данные (замени на сервис)
-  readonly project = {
-    id: this.idFromRoute,
-    name: this.idFromRoute === 'ai-review' ? 'AI Review Platform' : 'Project ' + this.idFromRoute,
-    description:
-      'Core company product for automated code reviews with machine learning capabilities',
-    pipelines: <PipelineRow[]>[
-      { id: 'p-main', name: 'Main Pipeline (main branch)', status: 'Active', lastRun: '2024-01-15T14:30:00Z' },
-      { id: 'p-log', name: 'Log Analysis (staging)', status: 'Inactive', lastRun: '2024-01-14T11:00:00Z' },
-      { id: 'p-perf', name: 'Performance Testing', status: 'Active', lastRun: '2024-01-15T09:15:00Z' },
-    ],
+  readonly idFromRoute: string;
+  readonly project: {
+    id: string;
+    name: string;
+    description: string;
+    pipelines: PipelineRow[];
   };
+
+  constructor(private router: Router, private route: ActivatedRoute) {
+    this.idFromRoute = this.route.snapshot.paramMap.get('id') ?? '';
+    // мок-данные (замени на сервис)
+    this.project = {
+      id: this.idFromRoute,
+      name: this.idFromRoute === 'ai-review' ? 'AI Review Platform' : 'Project ' + this.idFromRoute,
+      description:
+        'Core company product for automated code reviews with machine learning capabilities',
+      pipelines: <PipelineRow[]>[
+        { id: 'p-main', name: 'Main Pipeline (main branch)', status: 'Active', lastRun: '2024-01-15T14:30:00Z' },
+        { id: 'p-log', name: 'Log Analysis (staging)', status: 'Inactive', lastRun: '2024-01-14T11:00:00Z' },
+        { id: 'p-perf', name: 'Performance Testing', status: 'Active', lastRun: '2024-01-15T09:15:00Z' },
+      ],
+    };
+  }
+
+  openCreatePipelineModal(projectId: string) {
+    this.router.navigate(
+      [{ outlets: { modal: ['projects', projectId, 'pipelines', 'new'] } }],
+      { relativeTo: this.route.root }
+    );
+  }
 }
 


### PR DESCRIPTION
## Summary
- route create pipeline modal via named outlet and expose modal outlet in layout
- open create-pipeline modal from project detail
- restyle create project form fields for dark theme

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8debdbdec8321949f02abbcc605a2