### PR TITLE
feat: expose CI/CD admin services via REST

### DIFF
--- a/backend/src/AICodeReview.Application/Services/AiModelAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/AiModelAppService.cs
@@ -1,5 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -10,6 +12,8 @@ using AICodeReview.AiModels.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.AiModels.Default)]
+[RemoteService]
+[Route("api/app/ai-models")]
 public class AiModelAppService :
     CrudAppService<AiModel, AiModelDto, Guid, PagedAndSortedResultRequestDto, AiModelCreateDto, AiModelUpdateDto>,
     IAiModelAppService

--- a/backend/src/AICodeReview.Application/Services/BranchAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/BranchAppService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -12,6 +14,8 @@ using AICodeReview.Branches.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Branches.Default)]
+[RemoteService]
+[Route("api/app/branches")]
 public class BranchAppService :
     CrudAppService<Branch, BranchDto, Guid, BranchGetListInput, BranchCreateDto, BranchUpdateDto>,
     IBranchAppService

--- a/backend/src/AICodeReview.Application/Services/GroupAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/GroupAppService.cs
@@ -1,5 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -10,6 +12,8 @@ using AICodeReview.Groups.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Groups.Default)]
+[RemoteService]
+[Route("api/app/groups")]
 public class GroupAppService :
     CrudAppService<Group, GroupDto, Guid, PagedAndSortedResultRequestDto, GroupCreateDto, GroupUpdateDto>,
     IGroupAppService

--- a/backend/src/AICodeReview.Application/Services/GroupProjectAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/GroupProjectAppService.cs
@@ -1,5 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -10,6 +12,8 @@ using AICodeReview.Groups.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Groups.Default)]
+[RemoteService]
+[Route("api/app/group-projects")]
 public class GroupProjectAppService :
     CrudAppService<GroupProject, GroupProjectDto, Guid, PagedAndSortedResultRequestDto, GroupProjectCreateDto, GroupProjectUpdateDto>,
     IGroupProjectAppService

--- a/backend/src/AICodeReview.Application/Services/NodeAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/NodeAppService.cs
@@ -1,5 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -10,6 +12,8 @@ using AICodeReview.Nodes.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Nodes.Default)]
+[RemoteService]
+[Route("api/app/nodes")]
 public class NodeAppService :
     CrudAppService<Node, NodeDto, Guid, PagedAndSortedResultRequestDto, NodeCreateDto, NodeCreateDto>,
     INodeAppService

--- a/backend/src/AICodeReview.Application/Services/PipelineAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/PipelineAppService.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -14,6 +16,8 @@ using AICodeReview.Projects;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Pipelines.Default)]
+[RemoteService]
+[Route("api/app/pipelines")]
 public class PipelineAppService :
     CrudAppService<Pipeline, PipelineDto, Guid, PagedAndSortedResultRequestDto, PipelineCreateDto, PipelineUpdateDto>,
     IPipelineAppService

--- a/backend/src/AICodeReview.Application/Services/PipelineNodeAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/PipelineNodeAppService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -15,6 +17,8 @@ using AICodeReview.Nodes.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Nodes.Default)]
+[RemoteService]
+[Route("api/app/pipeline-nodes")]
 public class PipelineNodeAppService :
     CrudAppService<PipelineNode, PipelineNodeDto, Guid, PagedAndSortedResultRequestDto, PipelineNodeCreateDto, PipelineNodeCreateDto>,
     IPipelineNodeAppService

--- a/backend/src/AICodeReview.Application/Services/ProjectAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/ProjectAppService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -19,6 +21,8 @@ using AICodeReview.Mapping;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Projects.Default)]
+[RemoteService]
+[Route("api/app/projects")]
 public class ProjectAppService :
     CrudAppService<Project, ProjectDto, Guid, PagedAndSortedResultRequestDto, ProjectCreateDto, ProjectUpdateDto>,
     IProjectAppService

--- a/backend/src/AICodeReview.Application/Services/RepositoryAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/RepositoryAppService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -12,6 +14,8 @@ using AICodeReview.Repositories.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Repositories.Default)]
+[RemoteService]
+[Route("api/app/repositories")]
 public class RepositoryAppService :
     CrudAppService<Repository, RepositoryDto, Guid, RepositoryGetListInput, RepositoryCreateDto, RepositoryUpdateDto>,
     IRepositoryAppService

--- a/backend/src/AICodeReview.Application/Services/TriggerAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/TriggerAppService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -12,6 +14,8 @@ using AICodeReview.Triggers.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Triggers.Default)]
+[RemoteService]
+[Route("api/app/triggers")]
 public class TriggerAppService :
     CrudAppService<Trigger, TriggerDto, Guid, TriggerGetListInput, TriggerCreateDto, TriggerUpdateDto>,
     ITriggerAppService


### PR DESCRIPTION
## Summary
- expose CI/CD admin app services with explicit RemoteService and REST routes
- keep project and pipeline helper endpoints for summary, pipeline lists, node management

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba97398a3483218b7f484a5edefafc