### PR TITLE
feat: add validation and filtering for CI/CD entities

### DIFF
--- a/backend/src/AICodeReview.Application.Contracts/AiModels/AiModelDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/AiModels/AiModelDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.AiModels.Dtos;
 
@@ -15,20 +17,46 @@ public class AiModelDto : EntityDto<Guid>
 
 public class AiModelCreateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.Name)]
     public string Name { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Provider)]
     public string Provider { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Model)]
     public string Model { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.ApiBaseUrl)]
     public string? ApiBaseUrl { get; set; }
+
+    [StringLength(CicdConsts.Lengths.ApiKey)]
     public string? ApiKey { get; set; }
+
     public bool IsActive { get; set; } = true;
 }
 
 public class AiModelUpdateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.Name)]
     public string Name { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Provider)]
     public string Provider { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Model)]
     public string Model { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.ApiBaseUrl)]
     public string? ApiBaseUrl { get; set; }
+
+    [StringLength(CicdConsts.Lengths.ApiKey)]
     public string? ApiKey { get; set; }
+
     public bool IsActive { get; set; }
 }

--- a/backend/src/AICodeReview.Application.Contracts/Branches/BranchDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Branches/BranchDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.Branches.Dtos;
 
@@ -15,12 +17,16 @@ public class BranchDto : EntityDto<Guid>
 public class BranchCreateDto
 {
     public Guid RepositoryId { get; set; }
+    [Required]
+    [StringLength(CicdConsts.Lengths.BranchName)]
     public string Name { get; set; } = default!;
     public bool IsDefault { get; set; }
 }
 
 public class BranchUpdateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.BranchName)]
     public string Name { get; set; } = default!;
     public bool IsDefault { get; set; }
 }
@@ -28,4 +34,5 @@ public class BranchUpdateDto
 public class BranchGetListInput : PagedAndSortedResultRequestDto
 {
     public Guid? RepositoryId { get; set; }
+    public string? Filter { get; set; }
 }

--- a/backend/src/AICodeReview.Application.Contracts/Groups/GroupDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Groups/GroupDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.Groups.Dtos;
 
@@ -12,13 +14,21 @@ public class GroupDto : EntityDto<Guid>
 
 public class GroupCreateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.Description)]
     public string? Description { get; set; }
 }
 
 public class GroupUpdateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.Description)]
     public string? Description { get; set; }
 }
 

--- a/backend/src/AICodeReview.Application.Contracts/Pipelines/IPipelineAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Pipelines/IPipelineAppService.cs
@@ -5,7 +5,7 @@ using Volo.Abp.Application.Services;
 
 namespace AICodeReview.Pipelines.Dtos;
 
-public interface IPipelineAppService : ICrudAppService<PipelineDto, Guid, PagedAndSortedResultRequestDto, PipelineCreateDto, PipelineUpdateDto>
+public interface IPipelineAppService : ICrudAppService<PipelineDto, Guid, PipelineGetListInput, PipelineCreateDto, PipelineUpdateDto>
 {
-    Task<PagedResultDto<PipelineListItemDto>> GetAllAsync(PagedAndSortedResultRequestDto input);
+    Task<PagedResultDto<PipelineListItemDto>> GetAllAsync(PipelineGetListInput input);
 }

--- a/backend/src/AICodeReview.Application.Contracts/Pipelines/PipelineDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Pipelines/PipelineDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.Pipelines.Dtos;
 
@@ -18,14 +20,24 @@ public class PipelineDto : EntityDto<Guid>
 public class PipelineCreateDto
 {
     public Guid ProjectId { get; set; }
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.PipelineStatus)]
     public string Status { get; set; } = default!;
     public bool IsActive { get; set; } = true;
 }
 
 public class PipelineUpdateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.PipelineStatus)]
     public string Status { get; set; } = default!;
     public bool IsActive { get; set; }
 }
@@ -37,4 +49,10 @@ public class PipelineListItemDto : EntityDto<Guid>
     public string Status { get; set; } = default!;
     public string? Trigger { get; set; }
     public DateTime? LastRun { get; set; }
+}
+
+public class PipelineGetListInput : PagedAndSortedResultRequestDto
+{
+    public Guid? ProjectId { get; set; }
+    public string? Filter { get; set; }
 }

--- a/backend/src/AICodeReview.Application.Contracts/Projects/IProjectAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Projects/IProjectAppService.cs
@@ -7,7 +7,7 @@ using AICodeReview.Pipelines.Dtos;
 
 namespace AICodeReview.Projects.Dtos;
 
-public interface IProjectAppService : ICrudAppService<ProjectDto, Guid, PagedAndSortedResultRequestDto, ProjectCreateDto, ProjectUpdateDto>
+public interface IProjectAppService : ICrudAppService<ProjectDto, Guid, ProjectGetListInput, ProjectCreateDto, ProjectUpdateDto>
 {
     Task<ProjectSummaryDto> GetSummaryAsync(Guid id);
     Task<List<PipelineListItemDto>> GetPipelinesAsync(Guid id);

--- a/backend/src/AICodeReview.Application.Contracts/Projects/ProjectDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Projects/ProjectDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.Projects.Dtos;
 
@@ -16,22 +18,51 @@ public class ProjectDto : EntityDto<Guid>
 
 public class ProjectCreateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.Description)]
     public string? Description { get; set; }
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Provider)]
     public string Provider { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.RepoPath)]
     public string RepoPath { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.DefaultBranch)]
     public string DefaultBranch { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.AccessToken)]
     public string? GitAccessToken { get; set; }
+
     public bool IsActive { get; set; } = true;
 }
 
 public class ProjectUpdateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.Description)]
     public string? Description { get; set; }
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.RepoPath)]
     public string RepoPath { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.DefaultBranch)]
     public string DefaultBranch { get; set; } = default!;
+
     public bool IsActive { get; set; }
+
+    [StringLength(CicdConsts.Lengths.AccessToken)]
     public string? GitAccessToken { get; set; }
 }
 
@@ -43,4 +74,9 @@ public class ProjectSummaryDto : EntityDto<Guid>
     public string DefaultBranch { get; set; } = default!;
     public int ActivePipelinesCount { get; set; }
     public int TotalPipelinesCount { get; set; }
+}
+
+public class ProjectGetListInput : PagedAndSortedResultRequestDto
+{
+    public string? Filter { get; set; }
 }

--- a/backend/src/AICodeReview.Application.Contracts/Repositories/RepositoryDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Repositories/RepositoryDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.Repositories.Dtos;
 
@@ -16,16 +18,30 @@ public class RepositoryDto : EntityDto<Guid>
 public class RepositoryCreateDto
 {
     public Guid ProjectId { get; set; }
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Url)]
     public string Url { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.Url)]
     public string? WebhookUrl { get; set; }
     public bool IsActive { get; set; } = true;
 }
 
 public class RepositoryUpdateDto
 {
+    [Required]
+    [StringLength(CicdConsts.Lengths.NameLong)]
     public string Name { get; set; } = default!;
+
+    [Required]
+    [StringLength(CicdConsts.Lengths.Url)]
     public string Url { get; set; } = default!;
+
+    [StringLength(CicdConsts.Lengths.Url)]
     public string? WebhookUrl { get; set; }
     public bool IsActive { get; set; }
 }
@@ -33,4 +49,5 @@ public class RepositoryUpdateDto
 public class RepositoryGetListInput : PagedAndSortedResultRequestDto
 {
     public Guid? ProjectId { get; set; }
+    public string? Filter { get; set; }
 }

--- a/backend/src/AICodeReview.Application.Contracts/Triggers/TriggerDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Triggers/TriggerDtos.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using Volo.Abp.Application.Dtos;
+using AICodeReview.Consts;
 
 namespace AICodeReview.Triggers.Dtos;
 
@@ -17,6 +19,7 @@ public class TriggerCreateDto
     public long TypeId { get; set; }
     public Guid RepositoryId { get; set; }
     public Guid BranchId { get; set; }
+    [StringLength(CicdConsts.Lengths.Description)]
     public string? ScheduleJson { get; set; }
 }
 
@@ -25,6 +28,7 @@ public class TriggerUpdateDto
     public long TypeId { get; set; }
     public Guid RepositoryId { get; set; }
     public Guid BranchId { get; set; }
+    [StringLength(CicdConsts.Lengths.Description)]
     public string? ScheduleJson { get; set; }
 }
 

--- a/backend/src/AICodeReview.Application/Services/BranchAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/BranchAppService.cs
@@ -7,6 +7,7 @@ using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Linq;
+using Microsoft.EntityFrameworkCore;
 using AICodeReview.Permissions;
 using AICodeReview.Branches;
 using AICodeReview.Branches.Dtos;
@@ -34,6 +35,7 @@ public class BranchAppService :
     protected override IQueryable<Branch> CreateFilteredQuery(BranchGetListInput input)
     {
         return base.CreateFilteredQuery(input)
-            .WhereIf(input.RepositoryId.HasValue, x => x.RepositoryId == input.RepositoryId);
+            .WhereIf(input.RepositoryId.HasValue, x => x.RepositoryId == input.RepositoryId)
+            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => EF.Functions.Like(x.Name, $"%{input.Filter}%"));
     }
 }

--- a/backend/src/AICodeReview.Application/Services/ProjectAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/ProjectAppService.cs
@@ -11,6 +11,7 @@ using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Entities;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp;
+using Volo.Abp.Linq;
 using AICodeReview.Permissions;
 using AICodeReview.Projects;
 using AICodeReview.Projects.Dtos;
@@ -24,7 +25,7 @@ namespace AICodeReview.Services;
 [RemoteService]
 [Route("api/app/projects")]
 public class ProjectAppService :
-    CrudAppService<Project, ProjectDto, Guid, PagedAndSortedResultRequestDto, ProjectCreateDto, ProjectUpdateDto>,
+    CrudAppService<Project, ProjectDto, Guid, ProjectGetListInput, ProjectCreateDto, ProjectUpdateDto>,
     IProjectAppService
 {
     protected override string GetPolicyName { get; set; } = AICodeReviewPermissions.Projects.Default;
@@ -43,6 +44,12 @@ public class ProjectAppService :
     {
         _pipelineRepository = pipelineRepository;
         _projectRepository = repository;
+    }
+
+    protected override IQueryable<Project> CreateFilteredQuery(ProjectGetListInput input)
+    {
+        return base.CreateFilteredQuery(input)
+            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => EF.Functions.Like(x.Name, $"%{input.Filter}%"));
     }
 
     [HttpGet("{id}/summary")]

--- a/backend/src/AICodeReview.Application/Services/RepositoryAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/RepositoryAppService.cs
@@ -7,6 +7,7 @@ using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Linq;
+using Microsoft.EntityFrameworkCore;
 using AICodeReview.Permissions;
 using AICodeReview.Repositories;
 using AICodeReview.Repositories.Dtos;
@@ -34,6 +35,7 @@ public class RepositoryAppService :
     protected override IQueryable<Repository> CreateFilteredQuery(RepositoryGetListInput input)
     {
         return base.CreateFilteredQuery(input)
-            .WhereIf(input.ProjectId.HasValue, x => x.ProjectId == input.ProjectId);
+            .WhereIf(input.ProjectId.HasValue, x => x.ProjectId == input.ProjectId)
+            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => EF.Functions.Like(x.Name, $"%{input.Filter}%"));
     }
 }


### PR DESCRIPTION
## Summary
- add validation attributes to DTOs for core CI/CD entities
- support name filtering and project/repository scoping in list queries

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a46d3848321a881896382308562