### PR TITLE
refactor: clean EF configs and app services

### DIFF
--- a/backend/src/AICodeReview.Application.Contracts/AiModels/AiModelDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/AiModels/AiModelDtos.cs
@@ -60,3 +60,10 @@ public class AiModelUpdateDto
 
     public bool IsActive { get; set; }
 }
+
+public class AiModelGetListInput : PagedAndSortedResultRequestDto
+{
+    public string? Filter { get; set; }
+    public string? Provider { get; set; }
+    public bool? IsActive { get; set; }
+}

--- a/backend/src/AICodeReview.Application.Contracts/AiModels/IAiModelAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/AiModels/IAiModelAppService.cs
@@ -4,6 +4,6 @@ using Volo.Abp.Application.Services;
 
 namespace AICodeReview.AiModels.Dtos;
 
-public interface IAiModelAppService : ICrudAppService<AiModelDto, Guid, PagedAndSortedResultRequestDto, AiModelCreateDto, AiModelUpdateDto>
+public interface IAiModelAppService : ICrudAppService<AiModelDto, Guid, AiModelGetListInput, AiModelCreateDto, AiModelUpdateDto>
 {
 }

--- a/backend/src/AICodeReview.Application.Contracts/Groups/GroupDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Groups/GroupDtos.cs
@@ -47,3 +47,14 @@ public class GroupProjectCreateDto
 public class GroupProjectUpdateDto : GroupProjectCreateDto
 {
 }
+
+public class GroupGetListInput : PagedAndSortedResultRequestDto
+{
+    public string? Filter { get; set; }
+}
+
+public class GroupProjectGetListInput : PagedAndSortedResultRequestDto
+{
+    public Guid? GroupId { get; set; }
+    public Guid? ProjectId { get; set; }
+}

--- a/backend/src/AICodeReview.Application.Contracts/Groups/IGroupAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Groups/IGroupAppService.cs
@@ -4,6 +4,6 @@ using Volo.Abp.Application.Services;
 
 namespace AICodeReview.Groups.Dtos;
 
-public interface IGroupAppService : ICrudAppService<GroupDto, Guid, PagedAndSortedResultRequestDto, GroupCreateDto, GroupUpdateDto>
+public interface IGroupAppService : ICrudAppService<GroupDto, Guid, GroupGetListInput, GroupCreateDto, GroupUpdateDto>
 {
 }

--- a/backend/src/AICodeReview.Application.Contracts/Groups/IGroupProjectAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Groups/IGroupProjectAppService.cs
@@ -4,6 +4,6 @@ using Volo.Abp.Application.Services;
 
 namespace AICodeReview.Groups.Dtos;
 
-public interface IGroupProjectAppService : ICrudAppService<GroupProjectDto, Guid, PagedAndSortedResultRequestDto, GroupProjectCreateDto, GroupProjectUpdateDto>
+public interface IGroupProjectAppService : ICrudAppService<GroupProjectDto, Guid, GroupProjectGetListInput, GroupProjectCreateDto, GroupProjectUpdateDto>
 {
 }

--- a/backend/src/AICodeReview.Application.Contracts/Nodes/INodeAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Nodes/INodeAppService.cs
@@ -4,6 +4,6 @@ using Volo.Abp.Application.Services;
 
 namespace AICodeReview.Nodes.Dtos;
 
-public interface INodeAppService : ICrudAppService<NodeDto, Guid, PagedAndSortedResultRequestDto, NodeCreateDto>
+public interface INodeAppService : ICrudAppService<NodeDto, Guid, NodeGetListInput, NodeCreateDto>
 {
 }

--- a/backend/src/AICodeReview.Application.Contracts/Nodes/IPipelineNodeAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Nodes/IPipelineNodeAppService.cs
@@ -6,7 +6,7 @@ using Volo.Abp.Application.Services;
 
 namespace AICodeReview.Nodes.Dtos;
 
-public interface IPipelineNodeAppService : ICrudAppService<PipelineNodeDto, Guid, PagedAndSortedResultRequestDto, PipelineNodeCreateDto>
+public interface IPipelineNodeAppService : ICrudAppService<PipelineNodeDto, Guid, PipelineNodeGetListInput, PipelineNodeCreateDto>
 {
     Task<List<PipelineNodeDto>> GetPipelineNodesAsync(Guid pipelineId);
     Task ReorderAsync(Guid pipelineId, List<PipelineNodeReorderDto> input);

--- a/backend/src/AICodeReview.Application.Contracts/Nodes/NodeDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Nodes/NodeDtos.cs
@@ -29,3 +29,13 @@ public class PipelineNodeCreateDto
     public Guid NodeId { get; set; }
     public int Order { get; set; }
 }
+
+public class NodeGetListInput : PagedAndSortedResultRequestDto
+{
+    public long? TypeId { get; set; }
+}
+
+public class PipelineNodeGetListInput : PagedAndSortedResultRequestDto
+{
+    public Guid? PipelineId { get; set; }
+}

--- a/backend/src/AICodeReview.Application.Contracts/Projects/ProjectDtos.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Projects/ProjectDtos.cs
@@ -79,4 +79,6 @@ public class ProjectSummaryDto : EntityDto<Guid>
 public class ProjectGetListInput : PagedAndSortedResultRequestDto
 {
     public string? Filter { get; set; }
+    public string? Provider { get; set; }
+    public bool? IsActive { get; set; }
 }

--- a/backend/src/AICodeReview.Application/Services/AiModelAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/AiModelAppService.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -12,10 +11,8 @@ using AICodeReview.AiModels.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.AiModels.Default)]
-[RemoteService]
-[Route("api/app/ai-models")]
 public class AiModelAppService :
-    CrudAppService<AiModel, AiModelDto, Guid, PagedAndSortedResultRequestDto, AiModelCreateDto, AiModelUpdateDto>,
+    CrudAppService<AiModel, AiModelDto, Guid, AiModelGetListInput, AiModelCreateDto, AiModelUpdateDto>,
     IAiModelAppService
 {
     protected override string GetPolicyName { get; set; } = AICodeReviewPermissions.AiModels.Default;

--- a/backend/src/AICodeReview.Application/Services/BranchAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/BranchAppService.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Linq;
-using Microsoft.EntityFrameworkCore;
 using AICodeReview.Permissions;
 using AICodeReview.Branches;
 using AICodeReview.Branches.Dtos;
@@ -15,8 +13,6 @@ using AICodeReview.Branches.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Branches.Default)]
-[RemoteService]
-[Route("api/app/branches")]
 public class BranchAppService :
     CrudAppService<Branch, BranchDto, Guid, BranchGetListInput, BranchCreateDto, BranchUpdateDto>,
     IBranchAppService
@@ -36,6 +32,6 @@ public class BranchAppService :
     {
         return base.CreateFilteredQuery(input)
             .WhereIf(input.RepositoryId.HasValue, x => x.RepositoryId == input.RepositoryId)
-            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => EF.Functions.Like(x.Name, $"%{input.Filter}%"));
+            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => x.Name.Contains(input.Filter!));
     }
 }

--- a/backend/src/AICodeReview.Application/Services/GroupAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/GroupAppService.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -12,10 +11,8 @@ using AICodeReview.Groups.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Groups.Default)]
-[RemoteService]
-[Route("api/app/groups")]
 public class GroupAppService :
-    CrudAppService<Group, GroupDto, Guid, PagedAndSortedResultRequestDto, GroupCreateDto, GroupUpdateDto>,
+    CrudAppService<Group, GroupDto, Guid, GroupGetListInput, GroupCreateDto, GroupUpdateDto>,
     IGroupAppService
 {
     protected override string GetPolicyName { get; set; } = AICodeReviewPermissions.Groups.Default;

--- a/backend/src/AICodeReview.Application/Services/GroupProjectAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/GroupProjectAppService.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -12,10 +11,8 @@ using AICodeReview.Groups.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Groups.Default)]
-[RemoteService]
-[Route("api/app/group-projects")]
 public class GroupProjectAppService :
-    CrudAppService<GroupProject, GroupProjectDto, Guid, PagedAndSortedResultRequestDto, GroupProjectCreateDto, GroupProjectUpdateDto>,
+    CrudAppService<GroupProject, GroupProjectDto, Guid, GroupProjectGetListInput, GroupProjectCreateDto, GroupProjectUpdateDto>,
     IGroupProjectAppService
 {
     protected override string GetPolicyName { get; set; } = AICodeReviewPermissions.Groups.Default;

--- a/backend/src/AICodeReview.Application/Services/NodeAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/NodeAppService.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -12,10 +11,8 @@ using AICodeReview.Nodes.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Nodes.Default)]
-[RemoteService]
-[Route("api/app/nodes")]
 public class NodeAppService :
-    CrudAppService<Node, NodeDto, Guid, PagedAndSortedResultRequestDto, NodeCreateDto, NodeCreateDto>,
+    CrudAppService<Node, NodeDto, Guid, NodeGetListInput, NodeCreateDto>,
     INodeAppService
 {
     protected override string GetPolicyName { get; set; } = AICodeReviewPermissions.Nodes.Default;

--- a/backend/src/AICodeReview.Application/Services/PipelineNodeAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/PipelineNodeAppService.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
-using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
@@ -17,10 +15,8 @@ using AICodeReview.Nodes.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Nodes.Default)]
-[RemoteService]
-[Route("api/app/pipeline-nodes")]
 public class PipelineNodeAppService :
-    CrudAppService<PipelineNode, PipelineNodeDto, Guid, PagedAndSortedResultRequestDto, PipelineNodeCreateDto, PipelineNodeCreateDto>,
+    CrudAppService<PipelineNode, PipelineNodeDto, Guid, PipelineNodeGetListInput, PipelineNodeCreateDto>,
     IPipelineNodeAppService
 {
     protected override string GetPolicyName { get; set; } = AICodeReviewPermissions.Nodes.Default;
@@ -34,11 +30,9 @@ public class PipelineNodeAppService :
     {
     }
 
-    [HttpGet("/api/app/pipelines/{pipelineId}/nodes")]
     public virtual async Task<List<PipelineNodeDto>> GetPipelineNodesAsync(Guid pipelineId)
     {
         var query = (await Repository.GetQueryableAsync())
-            .AsNoTracking()
             .Where(x => x.PipelineId == pipelineId)
             .OrderBy(x => x.Order);
 
@@ -51,7 +45,6 @@ public class PipelineNodeAppService :
         }));
     }
 
-    [HttpPost("/api/app/pipelines/{pipelineId}/nodes/reorder")]
     public virtual async Task ReorderAsync(Guid pipelineId, List<PipelineNodeReorderDto> input)
     {
         var nodes = await Repository.GetListAsync(x => x.PipelineId == pipelineId);

--- a/backend/src/AICodeReview.Application/Services/RepositoryAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/RepositoryAppService.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Linq;
-using Microsoft.EntityFrameworkCore;
 using AICodeReview.Permissions;
 using AICodeReview.Repositories;
 using AICodeReview.Repositories.Dtos;
@@ -15,8 +13,6 @@ using AICodeReview.Repositories.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Repositories.Default)]
-[RemoteService]
-[Route("api/app/repositories")]
 public class RepositoryAppService :
     CrudAppService<Repository, RepositoryDto, Guid, RepositoryGetListInput, RepositoryCreateDto, RepositoryUpdateDto>,
     IRepositoryAppService
@@ -36,6 +32,6 @@ public class RepositoryAppService :
     {
         return base.CreateFilteredQuery(input)
             .WhereIf(input.ProjectId.HasValue, x => x.ProjectId == input.ProjectId)
-            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => EF.Functions.Like(x.Name, $"%{input.Filter}%"));
+            .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => x.Name.Contains(input.Filter!));
     }
 }

--- a/backend/src/AICodeReview.Application/Services/TriggerAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/TriggerAppService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -14,8 +13,6 @@ using AICodeReview.Triggers.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Triggers.Default)]
-[RemoteService]
-[Route("api/app/triggers")]
 public class TriggerAppService :
     CrudAppService<Trigger, TriggerDto, Guid, TriggerGetListInput, TriggerCreateDto, TriggerUpdateDto>,
     ITriggerAppService

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/AiModelConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/AiModelConfiguration.cs
@@ -3,6 +3,7 @@ namespace AICodeReview.EntityFrameworkCore.Configurations;
 using AICodeReview.AiModels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore.Modeling;
 
 public class AiModelConfiguration : IEntityTypeConfiguration<AiModel>
@@ -17,9 +18,12 @@ public class AiModelConfiguration : IEntityTypeConfiguration<AiModel>
         builder.Property(x => x.Model).IsRequired().HasMaxLength(128);
         builder.Property(x => x.ApiBaseUrl).HasMaxLength(256);
 
+        var apiKeyConverter = new ValueConverter<string?, string?>(
+            v => EfEncryption.Encrypt(v),
+            v => EfEncryption.Decrypt(v));
         builder.Property(x => x.ApiKey)
             .HasMaxLength(512)
-            .HasConversion(EfEncryption.Encrypt, EfEncryption.Decrypt);
+            .HasConversion(apiKeyConverter);
 
         builder.Property(x => x.IsActive).HasDefaultValue(true);
     }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/NodeTypeConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/NodeTypeConfiguration.cs
@@ -17,13 +17,6 @@ public class NodeTypeConfiguration : IEntityTypeConfiguration<NodeType>
         builder.Property(x => x.Name).IsRequired().HasMaxLength(64);
         builder.HasIndex(x => x.Name).IsUnique();
 
-        var seedTime = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        builder.HasData(
-            new NodeType { Id = 1, Name = "lint",    CreationTime = seedTime, ConcurrencyStamp = "lint",    ExtraProperties = new ExtraPropertyDictionary() },
-            new NodeType { Id = 2, Name = "test",    CreationTime = seedTime, ConcurrencyStamp = "test",    ExtraProperties = new ExtraPropertyDictionary() },
-            new NodeType { Id = 3, Name = "build",   CreationTime = seedTime, ConcurrencyStamp = "build",   ExtraProperties = new ExtraPropertyDictionary() },
-            new NodeType { Id = 4, Name = "deploy",  CreationTime = seedTime, ConcurrencyStamp = "deploy",  ExtraProperties = new ExtraPropertyDictionary() },
-            new NodeType { Id = 5, Name = "custom",  CreationTime = seedTime, ConcurrencyStamp = "custom",  ExtraProperties = new ExtraPropertyDictionary() }
-        );
+        // сидирование выполняется в миграции Add_CiCd_Schema
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/ProjectConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/ProjectConfiguration.cs
@@ -3,6 +3,7 @@ namespace AICodeReview.EntityFrameworkCore.Configurations;
 using AICodeReview.Projects;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore.Modeling;
 
 public class ProjectConfiguration : IEntityTypeConfiguration<Project>
@@ -18,9 +19,12 @@ public class ProjectConfiguration : IEntityTypeConfiguration<Project>
         builder.Property(x => x.RepoPath).IsRequired().HasMaxLength(512);
         builder.Property(x => x.DefaultBranch).IsRequired().HasMaxLength(128);
 
+        var tokenConverter = new ValueConverter<string?, string?> (
+            v => EfEncryption.Encrypt(v),
+            v => EfEncryption.Decrypt(v));
         builder.Property(x => x.GitAccessToken)
             .HasMaxLength(512)
-            .HasConversion(EfEncryption.Encrypt, EfEncryption.Decrypt);
+            .HasConversion(tokenConverter);
 
         builder.Property(x => x.IsActive).HasDefaultValue(true);
 

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/TriggerTypeConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/TriggerTypeConfiguration.cs
@@ -17,11 +17,6 @@ public class TriggerTypeConfiguration : IEntityTypeConfiguration<TriggerType>
         builder.Property(x => x.Name).IsRequired().HasMaxLength(64);
         builder.HasIndex(x => x.Name).IsUnique();
 
-        var seedTime = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        builder.HasData(
-            new TriggerType { Id = 1, Name = "manual",   CreationTime = seedTime, ConcurrencyStamp = "manual",   ExtraProperties = new ExtraPropertyDictionary() },
-            new TriggerType { Id = 2, Name = "push",     CreationTime = seedTime, ConcurrencyStamp = "push",     ExtraProperties = new ExtraPropertyDictionary() },
-            new TriggerType { Id = 3, Name = "schedule", CreationTime = seedTime, ConcurrencyStamp = "schedule", ExtraProperties = new ExtraPropertyDictionary() }
-        );
+        // сидирование выполняется в миграции Add_CiCd_Schema
     }
 }


### PR DESCRIPTION
## Summary
- remove inline seeding from node and trigger type configurations
- use explicit `ValueConverter` for API secrets in EF configs
- streamline application services, drop MVC attributes and fix `CrudAppService` generics

## Testing
- `dotnet build AICodeReview.sln` *(fails: command not found: dotnet)*
- `dotnet run --project backend/src/AICodeReview.DbMigrator/AICodeReview.DbMigrator.csproj` *(fails: command not found: dotnet)*
- `dotnet run --project backend/src/AICodeReview.HttpApi.Host/AICodeReview.HttpApi.Host.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68babdfbae5c8321b832362301fffe0c