### PR TITLE
feat: update ef core and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,33 @@ npm ci
 npm start
 npm run build
 ```
+
+## Админка/прокси
+
+1. Запустите Host и откройте Swagger.
+2. Сгенерируйте Angular proxies:
+
+```
+abp generate-proxy -t ng --with-typescript --url https://localhost:44300/swagger/v1/swagger.json --output src/app/proxy
+```
+
+## Backend
+
+```
+dotnet build .\backend\AICodeReview.sln
+dotnet run --project .\backend\src\AICodeReview.DbMigrator\AICodeReview.DbMigrator.csproj
+dotnet run --project .\backend\src\AICodeReview.HttpApi.Host\AICodeReview.HttpApi.Host.csproj
+```
+
+## Быстрые проверки
+
+```
+GET https://localhost:44300/api/app/projects?SkipCount=0&MaxResultCount=20&Sorting=Name
+GET https://localhost:44300/api/app/projects/{id}
+GET https://localhost:44300/api/app/projects/{id}/pipelines
+GET https://localhost:44300/api/app/pipelines/all?SkipCount=0&MaxResultCount=20&Sorting=StartedAt%20desc
+POST https://localhost:44300/api/app/pipelines
+# body = PipelineCreateDto
+GET https://localhost:44300/api/app/pipelines/{pipelineId}/nodes
+POST https://localhost:44300/api/app/pipelines/{pipelineId}/nodes/reorder
+```

--- a/backend/src/AICodeReview.Application.Contracts/Nodes/IPipelineNodeAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Nodes/IPipelineNodeAppService.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 
 namespace AICodeReview.Nodes.Dtos;
 
-public interface IPipelineNodeAppService : ICrudAppService<PipelineNodeDto, Guid, PipelineNodeGetListInput, PipelineNodeCreateDto>
+public interface IPipelineNodeAppService : IApplicationService
 {
-    Task<List<PipelineNodeDto>> GetPipelineNodesAsync(Guid pipelineId);
+    Task<List<PipelineNodeDto>> GetAsync(Guid pipelineId);
     Task ReorderAsync(Guid pipelineId, List<PipelineNodeReorderDto> input);
 }

--- a/backend/src/AICodeReview.Application.Contracts/Projects/IProjectAppService.cs
+++ b/backend/src/AICodeReview.Application.Contracts/Projects/IProjectAppService.cs
@@ -9,6 +9,6 @@ namespace AICodeReview.Projects.Dtos;
 
 public interface IProjectAppService : ICrudAppService<ProjectDto, Guid, ProjectGetListInput, ProjectCreateDto, ProjectUpdateDto>
 {
-    Task<ProjectSummaryDto> GetSummaryAsync(Guid id);
+    new Task<PagedResultDto<ProjectSummaryDto>> GetListAsync(ProjectGetListInput input);
     Task<List<PipelineListItemDto>> GetPipelinesAsync(Guid id);
 }

--- a/backend/src/AICodeReview.Application/Mapping/CicdProfiles.cs
+++ b/backend/src/AICodeReview.Application/Mapping/CicdProfiles.cs
@@ -75,12 +75,9 @@ public class CicdProfiles : Profile
         CreateMap<NodeCreateDto, Node>()
             .ForMember(d => d.Id, o => o.Ignore())
             .ForMember(d => d.ExtraProperties, o => o.MapFrom(s =>
-                s.ExtraProperties != null
-                    ? new ExtraPropertyDictionary(
-                        s.ExtraProperties.ToDictionary(kv => kv.Key, kv => (object?)kv.Value)
-                      )
-                    : new ExtraPropertyDictionary()
-            ));
+                s.ExtraProperties == null
+                    ? new ExtraPropertyDictionary()
+                    : new ExtraPropertyDictionary(s.ExtraProperties)));
 
         CreateMap<PipelineNode, PipelineNodeDto>();
         CreateMap<PipelineNodeCreateDto, PipelineNode>()
@@ -101,7 +98,18 @@ public class CicdProfiles : Profile
             .ForMember(d => d.Id, o => o.Ignore());
     }
 
-    // Выражение без использования навигации Pipelines (счётчики выставляются позже в сервисе)
+    public static Expression<Func<Project, ProjectSummaryDto>> ProjectToSummaryWithNavigation =>
+        p => new ProjectSummaryDto
+        {
+            Id = p.Id,
+            Name = p.Name,
+            Provider = p.Provider,
+            RepoPath = p.RepoPath,
+            DefaultBranch = p.DefaultBranch,
+            ActivePipelinesCount = p.Pipelines.Count(x => x.IsActive),
+            TotalPipelinesCount  = p.Pipelines.Count()
+        };
+
     public static Expression<Func<Project, ProjectSummaryDto>> ProjectToSummary =>
         p => new ProjectSummaryDto
         {

--- a/backend/src/AICodeReview.Application/Services/PipelineAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/PipelineAppService.cs
@@ -3,6 +3,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Linq.Dynamic.Core;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -16,6 +19,7 @@ using Volo.Abp.Linq;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Pipelines.Default)]
+[Route("api/app/pipelines")]
 public class PipelineAppService :
     CrudAppService<Pipeline, PipelineDto, Guid, PipelineGetListInput, PipelineCreateDto, PipelineUpdateDto>,
     IPipelineAppService
@@ -42,6 +46,9 @@ public class PipelineAppService :
             .WhereIf(!string.IsNullOrWhiteSpace(input.Filter), x => x.Name.Contains(input.Filter!));
     }
 
+    [HttpGet("all")]
+    [SwaggerOperation(Summary = "Get pipelines" )]
+    [ProducesResponseType(typeof(PagedResultDto<PipelineListItemDto>), StatusCodes.Status200OK)]
     public virtual async Task<PagedResultDto<PipelineListItemDto>> GetAllAsync(PipelineGetListInput input)
     {
         var pipelineQuery = await Repository.GetQueryableAsync();

--- a/backend/src/AICodeReview.DbMigrator/AICodeReview.DbMigrator.csproj
+++ b/backend/src/AICodeReview.DbMigrator/AICodeReview.DbMigrator.csproj
@@ -21,7 +21,18 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/backend/src/AICodeReview.Domain/Projects/Project.cs
+++ b/backend/src/AICodeReview.Domain/Projects/Project.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using AICodeReview.Pipelines;
+
 namespace AICodeReview.Projects;
 
 public class Project : CiCdAggregateRoot
@@ -9,4 +12,6 @@ public class Project : CiCdAggregateRoot
     public virtual string DefaultBranch { get; set; } = string.Empty;
     public virtual string? GitAccessToken { get; set; }
     public virtual bool IsActive { get; set; } = true;
+
+    public virtual ICollection<Pipeline> Pipelines { get; set; } = new List<Pipeline>();
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/AICodeReview.EntityFrameworkCore.csproj
+++ b/backend/src/AICodeReview.EntityFrameworkCore/AICodeReview.EntityFrameworkCore.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/BranchConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/BranchConfiguration.cs
@@ -19,7 +19,8 @@ public class BranchConfiguration : IEntityTypeConfiguration<Branch>
         builder.HasIndex(x => x.RepositoryId);
         builder.HasIndex(x => new { x.RepositoryId, x.Name }).IsUnique();
         builder.HasIndex(x => new { x.RepositoryId, x.IsDefault }).HasFilter("IsDefault = 1").IsUnique();
-        builder.HasOne<Repository>()
+
+        builder.HasOne(x => x.Repository)
             .WithMany()
             .HasForeignKey(x => x.RepositoryId)
             .OnDelete(DeleteBehavior.Cascade);

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/GroupProjectConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/GroupProjectConfiguration.cs
@@ -17,7 +17,14 @@ public class GroupProjectConfiguration : IEntityTypeConfiguration<GroupProject>
         builder.HasIndex(x => x.ProjectId);
         builder.HasIndex(x => new { x.GroupId, x.ProjectId }).IsUnique();
 
-        builder.HasOne<Group>().WithMany().HasForeignKey(x => x.GroupId).OnDelete(DeleteBehavior.Cascade);
-        builder.HasOne<Project>().WithMany().HasForeignKey(x => x.ProjectId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(x => x.Group)
+            .WithMany()
+            .HasForeignKey(x => x.GroupId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Project)
+            .WithMany()
+            .HasForeignKey(x => x.ProjectId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/NodeConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/NodeConfiguration.cs
@@ -13,6 +13,10 @@ public class NodeConfiguration : IEntityTypeConfiguration<Node>
         builder.ConfigureByConvention();
 
         builder.HasIndex(x => x.TypeId);
-        builder.HasOne<NodeType>().WithMany().HasForeignKey(x => x.TypeId).OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Type)
+            .WithMany()
+            .HasForeignKey(x => x.TypeId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/PipelineConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/PipelineConfiguration.cs
@@ -19,6 +19,10 @@ public class PipelineConfiguration : IEntityTypeConfiguration<Pipeline>
 
         builder.HasIndex(x => x.ProjectId);
         builder.HasIndex(x => new { x.ProjectId, x.Name }).IsUnique();
-        builder.HasOne<Project>().WithMany().HasForeignKey(x => x.ProjectId).OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Project)
+            .WithMany(p => p.Pipelines)
+            .HasForeignKey(x => x.ProjectId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/PipelineNodeConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/PipelineNodeConfiguration.cs
@@ -17,7 +17,14 @@ public class PipelineNodeConfiguration : IEntityTypeConfiguration<PipelineNode>
         builder.HasIndex(x => x.NodeId);
         builder.HasIndex(x => new { x.PipelineId, x.Order }).IsUnique();
 
-        builder.HasOne<Pipeline>().WithMany().HasForeignKey(x => x.PipelineId).OnDelete(DeleteBehavior.Cascade);
-        builder.HasOne<Node>().WithMany().HasForeignKey(x => x.NodeId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(x => x.Pipeline)
+            .WithMany()
+            .HasForeignKey(x => x.PipelineId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Node)
+            .WithMany()
+            .HasForeignKey(x => x.NodeId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/RepositoryConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/RepositoryConfiguration.cs
@@ -21,6 +21,10 @@ public class RepositoryConfiguration : IEntityTypeConfiguration<Repository>
         builder.HasIndex(x => x.ProjectId);
         builder.HasIndex(x => new { x.ProjectId, x.Name }).IsUnique();
         builder.HasIndex(x => new { x.TenantId, x.Url }).IsUnique();
-        builder.HasOne<Project>().WithMany().HasForeignKey(x => x.ProjectId).OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Project)
+            .WithMany()
+            .HasForeignKey(x => x.ProjectId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Configurations/TriggerConfiguration.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Configurations/TriggerConfiguration.cs
@@ -21,8 +21,19 @@ public class TriggerConfiguration : IEntityTypeConfiguration<Trigger>
         builder.HasIndex(x => x.TypeId);
         builder.HasIndex(x => new { x.RepositoryId, x.BranchId, x.TypeId }).IsUnique();
 
-        builder.HasOne<Repository>().WithMany().HasForeignKey(x => x.RepositoryId).OnDelete(DeleteBehavior.Cascade);
-        builder.HasOne<Branch>().WithMany().HasForeignKey(x => x.BranchId).OnDelete(DeleteBehavior.Cascade);
-        builder.HasOne<TriggerType>().WithMany().HasForeignKey(x => x.TypeId).OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(x => x.Repository)
+            .WithMany()
+            .HasForeignKey(x => x.RepositoryId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Branch)
+            .WithMany()
+            .HasForeignKey(x => x.BranchId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Type)
+            .WithMany()
+            .HasForeignKey(x => x.TypeId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReview.HttpApi.Host.csproj
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReview.HttpApi.Host.csproj
@@ -11,6 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/backend/test/AICodeReview.EntityFrameworkCore.Tests/AICodeReview.EntityFrameworkCore.Tests.csproj
+++ b/backend/test/AICodeReview.EntityFrameworkCore.Tests/AICodeReview.EntityFrameworkCore.Tests.csproj
@@ -11,6 +11,17 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\AICodeReview.EntityFrameworkCore\AICodeReview.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\AICodeReview.Application.Tests\AICodeReview.Application.Tests.csproj" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Volo.Abp.EntityFrameworkCore.Sqlite" Version="9.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- align EF Core packages to 9.0.8 across projects
- refine entity configurations and add navigation for pipelines
- expand services with admin endpoints and Swagger metadata
- document build and proxy generation steps in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae08ea02883219319480c349f32cc