### PR TITLE
refactor: remove mvc and swagger annotations from application services

### DIFF
--- a/backend/src/AICodeReview.Application/Services/PipelineNodeAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/PipelineNodeAppService.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Swashbuckle.AspNetCore.Annotations;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Linq;
@@ -16,7 +13,6 @@ using AICodeReview.Nodes.Dtos;
 namespace AICodeReview.Services
 {
     [Authorize(AICodeReviewPermissions.Nodes.Default)]
-    [Route("api/app/pipelines/{pipelineId}/nodes")]
     public class PipelineNodeAppService : ApplicationService, IPipelineNodeAppService
     {
         private readonly IRepository<PipelineNode, Guid> _repository;
@@ -26,9 +22,6 @@ namespace AICodeReview.Services
             _repository = repository;
         }
 
-        [HttpGet]
-        [SwaggerOperation(Summary = "Get pipeline nodes" )]
-        [ProducesResponseType(typeof(List<PipelineNodeDto>), StatusCodes.Status200OK)]
         public async Task<List<PipelineNodeDto>> GetAsync(Guid pipelineId)
         {
             var query = (await _repository.GetQueryableAsync())
@@ -44,9 +37,6 @@ namespace AICodeReview.Services
             }));
         }
 
-        [HttpPost("reorder")]
-        [SwaggerOperation(Summary = "Reorder pipeline nodes" )]
-        [ProducesResponseType(StatusCodes.Status204NoContent)]
         public async Task ReorderAsync(Guid pipelineId, List<PipelineNodeReorderDto> input)
         {
             var nodes = await _repository.GetListAsync(x => x.PipelineId == pipelineId);

--- a/backend/src/AICodeReview.Application/Services/ProjectAppService.cs
+++ b/backend/src/AICodeReview.Application/Services/ProjectAppService.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Swashbuckle.AspNetCore.Annotations;
 using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
@@ -20,7 +17,6 @@ using AICodeReview.Pipelines.Dtos;
 namespace AICodeReview.Services;
 
 [Authorize(AICodeReviewPermissions.Projects.Default)]
-[Route("api/app/projects")]
 public class ProjectAppService :
     CrudAppService<Project, ProjectDto, Guid, ProjectGetListInput, ProjectCreateDto, ProjectUpdateDto>,
     IProjectAppService
@@ -61,9 +57,6 @@ public class ProjectAppService :
         return query;
     }
 
-    [HttpGet]
-    [SwaggerOperation(Summary = "Get project summaries")]
-    [ProducesResponseType(typeof(PagedResultDto<ProjectSummaryDto>), StatusCodes.Status200OK)]
     public new virtual async Task<PagedResultDto<ProjectSummaryDto>> GetListAsync(ProjectGetListInput input)
     {
         var query = await CreateFilteredQueryAsync(input);
@@ -77,13 +70,8 @@ public class ProjectAppService :
         return new PagedResultDto<ProjectSummaryDto>(totalCount, items);
     }
 
-    [HttpGet("{id}")]
-    [ProducesResponseType(typeof(ProjectDto), StatusCodes.Status200OK)]
     public override Task<ProjectDto> GetAsync(Guid id) => base.GetAsync(id);
 
-    [HttpGet("{id}/pipelines")]
-    [SwaggerOperation(Summary = "Get project pipelines")]
-    [ProducesResponseType(typeof(List<PipelineListItemDto>), StatusCodes.Status200OK)]
     public virtual async Task<List<PipelineListItemDto>> GetPipelinesAsync(Guid id)
     {
         var pipelineQuery = await _pipelineRepository.GetQueryableAsync();


### PR DESCRIPTION
## Summary
- remove ASP.NET MVC and Swagger usings and attributes from application services

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bafa923c3c83218caf24d2db8a03fe