### PR TITLE
chore: improve migration infrastructure

### DIFF
--- a/backend/src/AICodeReview.DbMigrator/AICodeReviewDbMigratorModule.cs
+++ b/backend/src/AICodeReview.DbMigrator/AICodeReviewDbMigratorModule.cs
@@ -1,5 +1,7 @@
 using AICodeReview.Application.Contracts;
 using AICodeReview.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Volo.Abp;
 using Volo.Abp.Autofac;
 using Volo.Abp.Modularity;
 using Volo.Abp.Identity.EntityFrameworkCore;
@@ -28,4 +30,12 @@ namespace AICodeReview.DbMigrator;
 )]
 public class AICodeReviewDbMigratorModule : AbpModule
 {
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        Configure<AbpClockOptions>(o => o.Kind = DateTimeKind.Utc);
+        Configure<AbpBackgroundJobOptions>(o => o.IsJobExecutionEnabled = false);
+
+        // Ensure migration service is available when running outside the host
+        context.Services.AddTransient<AICodeReview.Data.AICodeReviewDbMigrationService>();
+    }
 }

--- a/backend/src/AICodeReview.DbMigrator/appsettings.json
+++ b/backend/src/AICodeReview.DbMigrator/appsettings.json
@@ -17,5 +17,8 @@
         "RootUrl": "https://localhost:44396"
       }
     }
+  },
+  "StringEncryption": {
+    "DefaultPassPhrase": "AICodeReviewDefaultPassPhrase"
   }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Design/AICodeReviewDbContextFactory.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Design/AICodeReviewDbContextFactory.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using AICodeReview.EntityFrameworkCore.Configurations;
+using AICodeReview.EntityFrameworkCore.Design;
 
 namespace AICodeReview.EntityFrameworkCore;
 
@@ -11,6 +13,7 @@ public class AICodeReviewDbContextFactory : IDesignTimeDbContextFactory<AICodeRe
         var cs = Environment.GetEnvironmentVariable("ConnectionStrings__Default")
                  ?? "Host=127.0.0.1;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC";
         var builder = new DbContextOptionsBuilder<AICodeReviewDbContext>();
+        EfEncryption.Service ??= new NoopStringEncryptionService();
         builder.UseNpgsql(cs);
         return new AICodeReviewDbContext(builder.Options);
     }

--- a/backend/src/AICodeReview.EntityFrameworkCore/Design/AICodeReviewMigrationsDbContextFactory.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/Design/AICodeReviewMigrationsDbContextFactory.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using AICodeReview.EntityFrameworkCore.Configurations;
+using AICodeReview.EntityFrameworkCore.Design;
 
 namespace AICodeReview.EntityFrameworkCore;
 
@@ -11,6 +13,7 @@ public class AICodeReviewMigrationsDbContextFactory : IDesignTimeDbContextFactor
         var cs = Environment.GetEnvironmentVariable("ConnectionStrings__Default")
                  ?? "Host=127.0.0.1;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC";
         var builder = new DbContextOptionsBuilder<AICodeReviewMigrationsDbContext>();
+        EfEncryption.Service ??= new NoopStringEncryptionService();
         builder.UseNpgsql(cs);
         return new AICodeReviewMigrationsDbContext(builder.Options);
     }

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.json
@@ -11,5 +11,9 @@
     "SelfUrl": "https://localhost:44300",
     "ClientUrl": "http://localhost:4200",
     "CorsOrigins": "http://localhost:4200"
-  }
+  },
+  "StringEncryption": {
+    "DefaultPassPhrase": "AICodeReviewDefaultPassPhrase"
+  },
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- configure DbMigrator with UTC clock, disabled background jobs and explicit migration service
- ensure design-time factories use env connection string and noop encryption
- add string encryption settings and allowed hosts for host

## Testing
- `dotnet clean && dotnet restore`
- `dotnet build`
- `dotnet ef migrations list -p backend/src/AICodeReview.EntityFrameworkCore -s backend/src/AICodeReview.DbMigrator --context AICodeReviewMigrationsDbContext`
- `dotnet run --project backend/src/AICodeReview.DbMigrator`
- `dotnet run --project backend/src/AICodeReview.HttpApi.Host`


------
https://chatgpt.com/codex/tasks/task_e_68bbf473e72c8321a0bc451c5256ece5