### PR TITLE
fix: align ABP API config

### DIFF
--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -38,6 +38,7 @@
     "@angular/platform-browser-dynamic": "^20.2.3",
     "@angular/router": "^20.2.0",
     "@swimlane/ngx-datatable": "^22.0.0",
+    "angular-oauth2-oidc": "^17.0.0",
     "lucide-angular": "^0.542.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/frontend/admin/src/environments/environment.prod.ts
+++ b/frontend/admin/src/environments/environment.prod.ts
@@ -15,7 +15,7 @@ export const environment = {
   application: { baseUrl, name: 'MergeSenseyAdmin' },
   oAuthConfig,
   apis: {
-    default: {
+    Default: {
       url: 'https://localhost:44396',
     },
   },

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
   },
   oAuthConfig,
   apis: {
-    default: {
+    Default: {
       url: 'https://localhost:44396',
     },
   },


### PR DESCRIPTION
## Summary
- use `Default` API key in Angular environments to match service `apiName`
- add angular-oauth2-oidc dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc40372f88321a594e2a943694863