### PR TITLE
Fix issuer, locale imports and favicon in admin frontend

### DIFF
--- a/frontend/admin/src/environments/environment.prod.ts
+++ b/frontend/admin/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ import { Environment } from '@abp/ng.core';
 
 const baseUrl = window.location.origin;
 const oAuthConfig = {
-  issuer: 'https://localhost:44396',
+  issuer: 'https://localhost:44396/',
   redirectUri: baseUrl,
   clientId: 'MergeSensei_App',
   responseType: 'code',
@@ -15,6 +15,9 @@ export const environment = {
   application: { baseUrl, name: 'MergeSenseyAdmin' },
   oAuthConfig,
   apis: {
+    default: {
+      url: 'https://localhost:44396',
+    },
     Default: {
       url: 'https://localhost:44396',
     },

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -3,7 +3,7 @@ import { Environment } from '@abp/ng.core';
 const baseUrl = window.location.origin;
 
 const oAuthConfig = {
-  issuer: 'https://localhost:44396',
+  issuer: 'https://localhost:44396/',
   redirectUri: baseUrl,
   clientId: 'MergeSensei_App',
   responseType: 'code',
@@ -19,6 +19,9 @@ export const environment = {
   },
   oAuthConfig,
   apis: {
+    default: {
+      url: 'https://localhost:44396',
+    },
     Default: {
       url: 'https://localhost:44396',
     },

--- a/frontend/admin/src/index.html
+++ b/frontend/admin/src/index.html
@@ -5,7 +5,7 @@
   <title>Admin</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/png" href="assets/logo.png" />
 </head>
 <body class="min-h-screen font-sans bg-[#0f1114] text-gray-100">
   <app-root></app-root>

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -14,7 +14,9 @@ bootstrapApplication(AppComponent, {
     provideHttpClient(withInterceptorsFromDi()),
     provideAbpCore(withOptions({
       environment,
-      registerLocaleFn: (locale: string) => import(`@angular/common/locales/${locale}.mjs`),
+      registerLocaleFn: (locale: string) =>
+        import(`@angular/common/locales/${locale}`)
+          .catch(() => import(`@angular/common/locales/${locale}.mjs`)),
     })),
     provideAbpOAuth(),
   ],


### PR DESCRIPTION
## Summary
- ensure OAuth issuer matches discovery document with trailing slash
- load Angular locales without hardcoded `.mjs` extension
- point favicon to existing logo asset

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdcbc070b08321ba49c0e899453b48