### PR TITLE
chore: configure dev issuer and cors

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/Program.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/Program.cs
@@ -32,6 +32,23 @@ public class Program
             Log.Information("Starting AICodeReview.HttpApi.Host.");
 
             var builder = WebApplication.CreateBuilder(args);
+            var configuration = builder.Configuration;
+
+            // CORS
+            builder.Services.AddCors(options =>
+            {
+                options.AddDefaultPolicy(policy =>
+                {
+                    var origins = configuration["App:CorsOrigins"]
+                        ?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        ?? Array.Empty<string>();
+
+                    policy.WithOrigins(origins)
+                          .AllowAnyHeader()
+                          .AllowAnyMethod()
+                          .AllowCredentials();
+                });
+            });
 
             builder.Host
                 .AddAppSettingsSecretsJson() // подхватит appsettings.secrets.json при наличии
@@ -40,6 +57,8 @@ public class Program
 
             await builder.AddApplicationAsync<AICodeReviewHttpApiHostModule>();
             var app = builder.Build();
+
+            app.UseCors(); // place before auth
 
             await app.InitializeApplicationAsync();
             await app.RunAsync();

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.json
@@ -4,13 +4,13 @@
     "App": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC"
   },
   "AuthServer": {
-    "Authority": "https://localhost:44300",
+    "Authority": "https://localhost:44396",
     "SwaggerClientId": "AICodeReview_Swagger"
   },
   "App": {
     "SelfUrl": "https://localhost:44300",
     "ClientUrl": "http://localhost:4200",
-    "CorsOrigins": "http://localhost:4200"
+    "CorsOrigins": "http://localhost:4200,https://localhost:4200"
   },
   "StringEncryption": {
     "DefaultPassPhrase": "AICodeReviewDefaultPassPhrase"

--- a/frontend/admin/src/environments/environment.prod.ts
+++ b/frontend/admin/src/environments/environment.prod.ts
@@ -1,25 +1,20 @@
 import { Environment } from '@abp/ng.core';
 
 const baseUrl = window.location.origin;
-const oAuthConfig = {
-  issuer: 'https://localhost:44396/',
-  redirectUri: baseUrl,
-  clientId: 'MergeSensei_App',
-  responseType: 'code',
-  scope: 'offline_access openid profile MergeSensei',
-  requireHttps: true,
-};
 
 export const environment = {
   production: true,
   application: { baseUrl, name: 'MergeSenseyAdmin' },
-  oAuthConfig,
+  oAuthConfig: {
+    issuer: 'https://localhost:44396/',
+    redirectUri: baseUrl,
+    clientId: 'MergeSensei_App',
+    responseType: 'code',
+    scope: 'offline_access openid profile MergeSensei',
+    requireHttps: true,
+  },
   apis: {
-    default: {
-      url: 'https://localhost:44396',
-    },
-    Default: {
-      url: 'https://localhost:44396',
-    },
+    default: { url: 'https://localhost:44396' },
+    Default: { url: 'https://localhost:44396' },
   },
 } as Environment;

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -2,28 +2,20 @@ import { Environment } from '@abp/ng.core';
 
 const baseUrl = window.location.origin;
 
-const oAuthConfig = {
-  issuer: 'https://localhost:44396/',
-  redirectUri: baseUrl,
-  clientId: 'MergeSensei_App',
-  responseType: 'code',
-  scope: 'offline_access openid profile MergeSensei',
-  requireHttps: true,
-};
-
 export const environment = {
   production: false,
-  application: {
-    baseUrl,
-    name: 'MergeSenseyAdmin',
+  application: { baseUrl, name: 'MergeSenseyAdmin' },
+  oAuthConfig: {
+    issuer: 'https://localhost:44396/',
+    redirectUri: baseUrl,
+    clientId: 'MergeSensei_App',
+    responseType: 'code',
+    scope: 'offline_access openid profile MergeSensei',
+    requireHttps: true,
+    strictDiscoveryDocumentValidation: false, // dev-friendly
   },
-  oAuthConfig,
   apis: {
-    default: {
-      url: 'https://localhost:44396',
-    },
-    Default: {
-      url: 'https://localhost:44396',
-    },
+    default: { url: 'https://localhost:44396' },
+    Default: { url: 'https://localhost:44396' },
   },
 } as Environment;


### PR DESCRIPTION
## Summary
- allow dev builds to tolerate discovery issuer mismatches while keeping prod strict
- enable CORS for Angular dev origins and read origins from configuration

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be74d3ee148321b771b1657db0b13b