### PR TITLE
feat(auth): add OIDC auth routes and components

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -2,6 +2,29 @@ import { Routes } from '@angular/router';
 import { authGuard } from '@abp/ng.core';
 
 export const routes: Routes = [
+  // Public auth routes (no guard)
+  {
+    path: 'auth/login',
+    loadComponent: () => import('./auth/auth-login.component').then(m => m.AuthLoginComponent),
+  },
+  {
+    path: 'auth/callback',
+    loadComponent: () => import('./auth/auth-callback.component').then(m => m.AuthCallbackComponent),
+  },
+  {
+    path: 'auth/logout',
+    loadComponent: () => import('./auth/auth-logout.component').then(m => m.AuthLogoutComponent),
+  },
+  {
+    path: 'auth/logged-out',
+    loadComponent: () => import('./auth/auth-loggedout.component').then(m => m.AuthLoggedOutComponent),
+  },
+  {
+    path: 'auth/forbidden',
+    loadComponent: () => import('./auth/auth-forbidden.component').then(m => m.AuthForbiddenComponent),
+  },
+
+  // Guarded shell
   {
     path: '',
     canActivate: [authGuard],

--- a/frontend/admin/src/app/auth/auth-callback.component.html
+++ b/frontend/admin/src/app/auth/auth-callback.component.html
@@ -1,0 +1,5 @@
+<div class="min-h-screen grid place-items-center p-6">
+  <div class="text-center">
+    <div class="text-lg">Завершаем вход…</div>
+  </div>
+</div>

--- a/frontend/admin/src/app/auth/auth-callback.component.ts
+++ b/frontend/admin/src/app/auth/auth-callback.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Component({
+  selector: 'app-auth-callback',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './auth-callback.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthCallbackComponent {
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+
+  async ngOnInit() {
+    const ok = await this.auth.completeLogin();
+    await this.router.navigateByUrl(ok ? '/' : '/auth/login');
+  }
+}

--- a/frontend/admin/src/app/auth/auth-forbidden.component.html
+++ b/frontend/admin/src/app/auth/auth-forbidden.component.html
@@ -1,0 +1,6 @@
+<div class="min-h-screen grid place-items-center p-6">
+  <div class="text-center">
+    <div class="text-2xl font-semibold mb-2">Доступ запрещён</div>
+    <div class="text-gray-500">У вас нет прав для просмотра этой страницы.</div>
+  </div>
+</div>

--- a/frontend/admin/src/app/auth/auth-forbidden.component.ts
+++ b/frontend/admin/src/app/auth/auth-forbidden.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-auth-forbidden',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './auth-forbidden.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthForbiddenComponent {}

--- a/frontend/admin/src/app/auth/auth-loggedout.component.html
+++ b/frontend/admin/src/app/auth/auth-loggedout.component.html
@@ -1,0 +1,6 @@
+<div class="min-h-screen grid place-items-center p-6">
+  <div class="text-center">
+    <div class="text-lg mb-2">Вы вышли из системы</div>
+    <a href="/" class="text-blue-600 underline">На главную</a>
+  </div>
+</div>

--- a/frontend/admin/src/app/auth/auth-loggedout.component.ts
+++ b/frontend/admin/src/app/auth/auth-loggedout.component.ts
@@ -1,0 +1,11 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-auth-loggedout',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './auth-loggedout.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthLoggedOutComponent {}

--- a/frontend/admin/src/app/auth/auth-login.component.html
+++ b/frontend/admin/src/app/auth/auth-login.component.html
@@ -1,0 +1,11 @@
+<div class="min-h-screen grid place-items-center p-6">
+  <div class="max-w-sm w-full rounded-xl p-6 shadow">
+    <h1 class="text-2xl font-semibold mb-4">Вход</h1>
+    <p class="text-sm text-gray-500 mb-6">
+      Для продолжения нажмите «Войти». Вы будете перенаправлены на страницу авторизации.
+    </p>
+    <button (click)="login()" class="w-full h-10 rounded-md px-4 font-medium bg-blue-600 text-white">
+      Войти
+    </button>
+  </div>
+</div>

--- a/frontend/admin/src/app/auth/auth-login.component.scss
+++ b/frontend/admin/src/app/auth/auth-login.component.scss
@@ -1,0 +1,1 @@
+/* optional */

--- a/frontend/admin/src/app/auth/auth-login.component.ts
+++ b/frontend/admin/src/app/auth/auth-login.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AuthService } from './auth.service';
+
+@Component({
+  selector: 'app-auth-login',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './auth-login.component.html',
+  styleUrls: ['./auth-login.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthLoginComponent {
+  private readonly auth = inject(AuthService);
+  login() { this.auth.login(); }
+}

--- a/frontend/admin/src/app/auth/auth-logout.component.html
+++ b/frontend/admin/src/app/auth/auth-logout.component.html
@@ -1,0 +1,5 @@
+<div class="min-h-screen grid place-items-center p-6">
+  <div class="text-center">
+    <div class="text-lg">Выходим…</div>
+  </div>
+</div>

--- a/frontend/admin/src/app/auth/auth-logout.component.ts
+++ b/frontend/admin/src/app/auth/auth-logout.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AuthService } from './auth.service';
+
+@Component({
+  selector: 'app-auth-logout',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './auth-logout.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthLogoutComponent {
+  private readonly auth = inject(AuthService);
+  ngOnInit() { this.auth.logout(); }
+}

--- a/frontend/admin/src/app/auth/auth.service.ts
+++ b/frontend/admin/src/app/auth/auth.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, inject } from '@angular/core';
+import { OAuthService, OAuthEvent } from 'angular-oauth2-oidc';
+import { filter, map, Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly oauth = inject(OAuthService);
+
+  initOnce(): Promise<void> {
+    // no-op here; ABP providers already bootstrapped OAuth. Keep method if needed later.
+    return Promise.resolve();
+  }
+
+  login(): void {
+    this.oauth.initCodeFlow(); // redirect to /connect/authorize (server login page)
+  }
+
+  async completeLogin(): Promise<boolean> {
+    await this.oauth.loadDiscoveryDocument(); // idempotent
+    await this.oauth.tryLoginCodeFlow();
+    return this.oauth.hasValidAccessToken();
+  }
+
+  logout(): void {
+    this.oauth.logOut(); // server-side logout if endsession supported
+  }
+
+  hasToken(): boolean {
+    return this.oauth.hasValidAccessToken();
+  }
+
+  accessToken(): string | null {
+    return this.oauth.getAccessToken() || null;
+  }
+
+  claims(): any {
+    return this.oauth.getIdentityClaims() || null;
+  }
+
+  userName(): string {
+    const c: any = this.claims();
+    return c?.name || c?.preferred_username || '';
+  }
+
+  events$(): Observable<OAuthEvent> {
+    return this.oauth.events.pipe(filter(e => !!e));
+  }
+}


### PR DESCRIPTION
## Summary
- add AuthService wrapper around angular-oauth2-oidc
- introduce standalone login, callback, logout and related views
- register public auth routes before guarded shell

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be79f25a848321961bced6f1d69035