### PR TITLE
chore: register migrations db context

### DIFF
--- a/backend/src/AICodeReview.DbMigrator/AICodeReviewDbMigratorModule.cs
+++ b/backend/src/AICodeReview.DbMigrator/AICodeReviewDbMigratorModule.cs
@@ -1,5 +1,7 @@
 using System;
 using AICodeReview.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp;
 using Volo.Abp.Autofac;
@@ -37,7 +39,15 @@ public class AICodeReviewDbMigratorModule : AbpModule
         Configure<AbpClockOptions>(o => o.Kind = DateTimeKind.Utc);
         
         Configure<AbpBackgroundJobOptions>(o => o.IsJobExecutionEnabled = false);
-        
+
+        var configuration = context.Services.GetConfiguration();
+
+        // Explicitly register the migrations DbContext so Autofac can resolve its options
+        context.Services.AddDbContext<AICodeReview.EntityFrameworkCore.AICodeReviewMigrationsDbContext>(options =>
+        {
+            options.UseNpgsql(configuration.GetConnectionString("Default"));
+        });
+
         context.Services.AddTransient<AICodeReview.Data.AICodeReviewDbMigrationService>();
     }
 }

--- a/backend/src/AICodeReview.EntityFrameworkCore/EntityFrameworkCore/EntityFrameworkCoreAICodeReviewDbSchemaMigrator.cs
+++ b/backend/src/AICodeReview.EntityFrameworkCore/EntityFrameworkCore/EntityFrameworkCoreAICodeReviewDbSchemaMigrator.cs
@@ -20,7 +20,16 @@ public class EntityFrameworkCoreAICodeReviewDbSchemaMigrator
     public async Task MigrateAsync()
     {
         // Сначала применяем миграции MIGRATIONS-контекста (содержит App* таблицы)
-        var migrationsCtx = _serviceProvider.GetService<AICodeReviewMigrationsDbContext>();
+        AICodeReviewMigrationsDbContext? migrationsCtx = null;
+        try
+        {
+            migrationsCtx = _serviceProvider.GetService<AICodeReviewMigrationsDbContext>();
+        }
+        catch
+        {
+            // ignore – we'll fall back to runtime context below
+        }
+
         if (migrationsCtx != null)
         {
             await migrationsCtx.Database.MigrateAsync();


### PR DESCRIPTION
## Summary
- register AICodeReviewMigrationsDbContext with Npgsql connection so migrator resolves options
- make schema migrator fall back to runtime context if migrations context resolution fails

## Testing
- `dotnet run --project backend/src/AICodeReview.DbMigrator/AICodeReview.DbMigrator.csproj` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be80b8b39c8321b28c3945521b323f