### PR TITLE
feat: refine spa redirect config and openiddict seeding

### DIFF
--- a/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -174,7 +174,7 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
         var existing = await applicationManager.FindByClientIdAsync(clientId);
         if (existing is not null)
         {
-            // Ensure collections are refreshed: delete & recreate for SPA (no secret)
+            // Delete to guarantee collections (RedirectUris/PostLogoutRedirectUris) are fully updated
             await applicationManager.DeleteAsync(existing);
         }
 
@@ -185,7 +185,7 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
             ConsentType = ConsentTypes.Implicit,
         };
 
-        // Set ClientType = Public (supports OpenIddict 3/4/5 via reflection)
+        // Set ClientType = Public (supports OpenIddict 3/4/5)
         var clientTypeProp = typeof(OpenIddictApplicationDescriptor).GetProperty("ClientType")
                              ?? typeof(OpenIddictApplicationDescriptor).GetProperty("Type");
         clientTypeProp?.SetValue(descriptor, ClientTypes.Public);
@@ -196,12 +196,11 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
         descriptor.PostLogoutRedirectUris.Clear();
         foreach (var u in postLogoutUris) descriptor.PostLogoutRedirectUris.Add(new Uri(u));
 
-        // Build permissions (version-safe)
+        // Permissions (version-safe)
         var perms = new HashSet<string>
         {
             Permissions.Endpoints.Authorization,
             Permissions.Endpoints.Token,
-            // omit Endpoints.Logout for compatibility
             Permissions.GrantTypes.AuthorizationCode,
             Permissions.ResponseTypes.Code,
             Permissions.Prefixes.Scope + Scopes.OpenId,

--- a/frontend/admin/src/environments/environment.prod.ts
+++ b/frontend/admin/src/environments/environment.prod.ts
@@ -6,8 +6,8 @@ export const environment = {
   production: true,
   application: { baseUrl, name: 'MergeSenseyAdmin' },
   oAuthConfig: {
-    issuer: 'https://localhost:44396/',
-    redirectUri: `${baseUrl}/auth/callback`,
+    issuer: 'https://localhost:44396/',          // trailing slash is required
+    redirectUri: `${baseUrl}/auth/callback`,     // explicit callback
     clientId: 'MergeSensei_App',
     responseType: 'code',
     scope: 'offline_access openid profile MergeSensei',

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -6,8 +6,8 @@ export const environment = {
   production: false,
   application: { baseUrl, name: 'MergeSenseyAdmin' },
   oAuthConfig: {
-    issuer: 'https://localhost:44396/',
-    redirectUri: `${baseUrl}/auth/callback`,
+    issuer: 'https://localhost:44396/',          // trailing slash is required
+    redirectUri: `${baseUrl}/auth/callback`,     // explicit callback
     clientId: 'MergeSensei_App',
     responseType: 'code',
     scope: 'offline_access openid profile MergeSensei',

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -14,7 +14,7 @@ bootstrapApplication(AppComponent, {
     provideHttpClient(withInterceptorsFromDi()),
     provideAbpCore(withOptions({
       environment,
-      registerLocaleFn: (locale: string) => {
+      registerLocaleFn: (locale: string) => { // static map avoids dynamic locale imports
         const loaders: Record<string, () => Promise<unknown>> = {
           ru: () => import('@angular/common/locales/ru'),
           en: () => import('@angular/common/locales/en'),


### PR DESCRIPTION
## Summary
- document static locale loader map
- comment explicit auth callback and issuer for SPA
- clarify OpenIddict SPA client recreation logic

## Testing
- `npm test --prefix frontend/admin`
- `dotnet run --project backend/src/AICodeReview.DbMigrator/AICodeReview.DbMigrator.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be8d0e869c8321aa17de7368540e13