### PR TITLE
fix: configure admin oauth client

### DIFF
--- a/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -108,7 +108,7 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
                 "offline_access"
             },
             clientUri: "http://localhost:4200",
-            redirectUri: "http://localhost:4200",
+            redirectUri: "http://localhost:4200/auth/callback",
             postLogoutRedirectUri: "http://localhost:4200"
         );
 

--- a/frontend/admin/src/environments/environment.prod.ts
+++ b/frontend/admin/src/environments/environment.prod.ts
@@ -8,9 +8,9 @@ export const environment = {
   oAuthConfig: {
     issuer: 'https://localhost:44396/',
     redirectUri: `${baseUrl}/auth/callback`,
-    clientId: 'MergeSensei_App',
+    clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',
-    scope: 'offline_access openid profile MergeSensei',
+    scope: 'offline_access openid profile AICodeReview',
     requireHttps: true,
   },
   apis: {

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -8,9 +8,9 @@ export const environment = {
   oAuthConfig: {
     issuer: 'https://localhost:44396/',
     redirectUri: `${baseUrl}/auth/callback`,
-    clientId: 'MergeSensei_App',
+    clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',
-    scope: 'offline_access openid profile MergeSensei',
+    scope: 'offline_access openid profile AICodeReview',
 
     requireHttps: false,
     strictDiscoveryDocumentValidation: false,


### PR DESCRIPTION
## Summary
- use MergeSenseyAdmin_Angular client id with AICodeReview scope in admin frontend
- align backend OpenIddict seed data with callback route

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68becaa6e6c083219a986fd74cc9b01e