### PR TITLE
feat: expand OpenIddict scopes and explicit consent

### DIFF
--- a/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -74,7 +74,7 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
     {
         var configurationSection = _configuration.GetSection("OpenIddict:Applications");
 
-        await EnsureScopeAsync(_scopeManager, "MergeSensei", "MergeSensei API");
+        await EnsureScopeAsync(_scopeManager, "MergeSensei", "MergeSensei API", "AICodeReview");
 
         var spaClientId = configurationSection["MergeSenseyAdmin_Angular:ClientId"];
         if (!spaClientId.IsNullOrWhiteSpace())
@@ -105,15 +105,25 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
         }
     }
 
-    private static async Task EnsureScopeAsync(IOpenIddictScopeManager scopeManager, string name, string displayName)
+    private static async Task EnsureScopeAsync(
+        IOpenIddictScopeManager scopeManager,
+        string name,
+        string displayName,
+        params string[] resources)
     {
         if (await scopeManager.FindByNameAsync(name) is null)
         {
-            await scopeManager.CreateAsync(new OpenIddictScopeDescriptor
+            var d = new OpenIddictScopeDescriptor
             {
                 Name = name,
                 DisplayName = displayName
-            });
+            };
+            if (resources != null)
+            {
+                foreach (var r in resources)
+                    d.Resources.Add(r);
+            }
+            await scopeManager.CreateAsync(d);
         }
     }
 
@@ -135,7 +145,7 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
         {
             ClientId = clientId,
             DisplayName = displayName,
-            ConsentType = ConsentTypes.Implicit,
+            ConsentType = ConsentTypes.Explicit,
         };
 
         // Set ClientType = Public (supports OpenIddict 3/4/5)
@@ -190,7 +200,7 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
         {
             ClientId = clientId,
             DisplayName = displayName,
-            ConsentType = ConsentTypes.Implicit,
+            ConsentType = ConsentTypes.Explicit,
         };
 
         var clientTypeProp = typeof(OpenIddictApplicationDescriptor).GetProperty("ClientType")

--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -219,8 +219,8 @@ public class AICodeReviewHttpApiHostModule : AbpModule
 
             var configuration = context.ServiceProvider.GetRequiredService<IConfiguration>();
             c.OAuthClientId(configuration["AuthServer:SwaggerClientId"]);
-            c.OAuthScopes("AICodeReview");
-            c.OAuthUsePkce(); // чуть безопаснее для SPA
+            c.OAuthUsePkce();
+            c.OAuthScopes("AICodeReview", "openid", "profile", "offline_access", "MergeSensei");
         });
 
         app.UseAuditing();


### PR DESCRIPTION
## Summary
- allow seeding scopes with resources and link MergeSensei to AICodeReview
- require explicit consent for SPA and Swagger clients
- request full scope set in Swagger UI

## Testing
- `dotnet build AICodeReview.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbd3c4c88321b89143e8d4e61002