### PR TITLE
feat: support SPA root redirect

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -1,14 +1,11 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './auth/auth.guard';
 
-
 export const routes: Routes = [
+  // Optional public login page (manual “Войти” button)
   { path: 'auth/login', loadComponent: () => import('./auth/auth-login.component').then(m => m.AuthLoginComponent) },
-  { path: 'auth/callback', loadComponent: () => import('./auth/auth-callback.component').then(m => m.AuthCallbackComponent) },
-  { path: 'auth/logout', loadComponent: () => import('./auth/auth-logout.component').then(m => m.AuthLogoutComponent) },
-  { path: 'auth/logged-out', loadComponent: () => import('./auth/auth-loggedout.component').then(m => m.AuthLoggedOutComponent) },
-  { path: 'auth/forbidden', loadComponent: () => import('./auth/auth-forbidden.component').then(m => m.AuthForbiddenComponent) },
 
+  // Protected shell
   {
     path: '',
     canActivateChild: [authGuard],
@@ -24,9 +21,10 @@ export const routes: Routes = [
       { path: 'pipelines/:id', loadComponent: () => import('./pages/pipeline-detail/pipeline-detail.component').then(m => m.PipelineDetailComponent) },
       { path: 'settings', loadComponent: () => import('./pages/settings/settings.component').then(m => m.SettingsComponent) },
       { path: 'help', loadComponent: () => import('./pages/help/help.component').then(m => m.HelpComponent) },
-      { path: '404', loadComponent: () => import('./pages/not-found/not-found.component').then(m => m.NotFoundComponent) },
       { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
-      { path: '**', redirectTo: '404' },
     ],
   },
+
+  // 404 fallback
+  { path: '**', redirectTo: '' },
 ];

--- a/frontend/admin/src/app/auth/auth.guard.ts
+++ b/frontend/admin/src/app/auth/auth.guard.ts
@@ -1,13 +1,43 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
-import { OAuthService } from 'angular-oauth2-oidc';
+import { CanActivateChildFn, CanActivateFn, Router } from '@angular/router';
+import { OAuthService, LoginOptions } from 'angular-oauth2-oidc';
 
-export const authGuard: CanActivateFn = (route, state) => {
+async function handle(stateUrl: string): Promise<boolean> {
   const oauth = inject(OAuthService);
   const router = inject(Router);
+  const url = new URL(window.location.href);
 
+  // 1) If we came back from the IdP with code/state — finish login
+  if (url.searchParams.has('code') && url.searchParams.has('state')) {
+    try {
+      const opts: LoginOptions = { disableOAuth2StateCheck: false };
+      await oauth.tryLoginCodeFlow(opts);
+
+      const ru = sessionStorage.getItem('returnUrl') || '/dashboard';
+      sessionStorage.removeItem('returnUrl');
+
+      // Cleanup query string and continue
+      await router.navigateByUrl(ru);
+      return false; // abort current navigation; we navigated manually
+    } catch {
+      await router.navigate(['/auth/login'], { queryParams: { returnUrl: stateUrl } });
+      return false;
+    }
+  }
+
+  // 2) Already have a valid access token? Allow
   if (oauth.hasValidAccessToken()) return true;
 
-  router.navigate(['/auth/login'], { queryParams: { returnUrl: state.url } });
+  // 3) No token — start login
+  sessionStorage.setItem('returnUrl', stateUrl);
+  try {
+    if (!(oauth as any).discoveryDocumentLoaded) {
+      await oauth.loadDiscoveryDocument();
+    }
+  } catch {}
+  oauth.initCodeFlow(); // redirect to /connect/authorize
   return false;
-};
+}
+
+export const authGuard: CanActivateChildFn = async (route, state) => handle(state.url);
+export const authGuardActivate: CanActivateFn = async (route, state) => handle(state.url);

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -1,21 +1,17 @@
 import { Environment } from '@abp/ng.core';
 
-const baseUrl = 'http://localhost:4200';
-
 export const environment = {
   production: false,
-  application: { baseUrl, name: 'MergeSenseyAdmin' },
+  application: { baseUrl: 'http://localhost:4200', name: 'MergeSenseyAdmin' },
   oAuthConfig: {
     issuer: 'https://localhost:44396/',
-    redirectUri: 'http://localhost:4200/auth/callback',
+    redirectUri: 'http://localhost:4200',              // <— ROOT, not /auth/callback
     clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',
     scope: 'offline_access openid profile MergeSensei',
-
     requireHttps: false,
     strictDiscoveryDocumentValidation: false,
     showDebugInformation: true,
-    // На всякий случай отключим сессионные проверки в DEV:
     sessionChecksEnabled: false,
   },
   apis: {


### PR DESCRIPTION
## Summary
- register SPA using root URL and PKCE in OpenIddict seed
- enable SPA code flow guard with root redirect
- update Angular routes and OAuth config for root-based callback

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee05390cc83218d4b63a5af7e8fdd