### PR TITLE
feat: improve oauth handling

### DIFF
--- a/frontend/admin/src/app/auth/auth.guard.ts
+++ b/frontend/admin/src/app/auth/auth.guard.ts
@@ -37,8 +37,16 @@ async function handle(stateUrl: string): Promise<boolean> {
   }
 
   if (oauth.hasValidAccessToken()) return true;
+  // ✅ NEW: если мы уже стоим на том же URL, который собираемся сохранить как returnUrl,
+  // просто кинем на логин сразу (без лишних «сохранений» и гонок навигации)
+  const currentUrl = router.routerState.snapshot.url || '/';
+  const plannedUrl = stateUrl || '/';
+  if (currentUrl === plannedUrl) {
+    oauth.initCodeFlow();
+    return false;
+  }
 
-  sessionStorage.setItem('returnUrl', stateUrl);
+  sessionStorage.setItem('returnUrl', plannedUrl);
   try {
     if (!(oauth as any).discoveryDocumentLoaded) {
       await oauth.loadDiscoveryDocument();


### PR DESCRIPTION
## Summary
- store OAuth state in sessionStorage during development
- set up automatic token refresh and discovery preloading
- avoid redundant login when navigating to same return URL

## Testing
- `npm test`
- `dotnet test` *(fails: dotnet not installed, apt repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bef249e4188321afd29a2b9b85fb0d