### PR TITLE
fix auth redirect loop and expose login errors

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -2,8 +2,9 @@ import { Routes } from '@angular/router';
 import { authGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
-  // опционально можно оставить публичный login:
-  // { path: 'auth/login', loadComponent: () => import('./auth/auth-login.component').then(m => m.AuthLoginComponent) },
+  { path: 'auth/login', loadComponent: () => import('./auth/auth-login.component').then(m => m.AuthLoginComponent) },
+  { path: 'auth/forbidden', loadComponent: () => import('./auth/auth-forbidden.component').then(m => m.AuthForbiddenComponent) },
+  { path: 'auth/loggedout', loadComponent: () => import('./auth/auth-loggedout.component').then(m => m.AuthLoggedOutComponent) },
 
   {
     path: '',

--- a/frontend/admin/src/app/auth/auth-login.component.html
+++ b/frontend/admin/src/app/auth/auth-login.component.html
@@ -1,5 +1,13 @@
 <div class="min-h-screen grid place-items-center p-6">
   <div class="max-w-sm w-full rounded-xl p-6 shadow">
+    @if (route.snapshot.queryParamMap.get('error') as err) {
+      <div class="mb-4 rounded-md border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">
+        Ошибка входа: <b>{{ err }}</b>
+        @if (route.snapshot.queryParamMap.get('error_description') as ed) {
+          <div class="mt-1 opacity-90">{{ ed }}</div>
+        }
+      </div>
+    }
     <h1 class="text-2xl font-semibold mb-4">Вход</h1>
     <p class="text-sm text-gray-500 mb-6">
       Для продолжения нажмите «Войти». Вы будете перенаправлены на страницу авторизации.

--- a/frontend/admin/src/app/auth/auth-login.component.ts
+++ b/frontend/admin/src/app/auth/auth-login.component.ts
@@ -13,7 +13,7 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class AuthLoginComponent {
   private readonly auth = inject(AuthService);
-  private readonly route = inject(ActivatedRoute);
+  public readonly route = inject(ActivatedRoute);
   async onLogin() {
     const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') || '/dashboard';
     await this.auth.login(returnUrl);

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -5,7 +5,8 @@ export const environment = {
   application: { baseUrl: 'http://localhost:4200', name: 'MergeSenseyAdmin' },
   oAuthConfig: {
     issuer: 'https://localhost:44396/',
-    redirectUri: 'http://localhost:4200',              // <— ROOT, not /auth/callback
+    redirectUri: 'http://localhost:4200/',           // с закрывающим слэшем
+    postLogoutRedirectUri: 'http://localhost:4200/', // добавь это поле
     clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',
     scope: 'offline_access openid profile MergeSensei',


### PR DESCRIPTION
## Summary
- allow public auth routes and guard shell
- stop guard redirect loops and show login errors
- ensure OAuth SPA config covers logout redirect

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0b19c8a8832190e78e847fd61091