### PR TITLE
Fix OAuth redirect and login flag reset

### DIFF
--- a/frontend/admin/src/app/auth/auth-login.component.ts
+++ b/frontend/admin/src/app/auth/auth-login.component.ts
@@ -14,6 +14,11 @@ import { ActivatedRoute } from '@angular/router';
 export class AuthLoginComponent {
   private readonly auth = inject(AuthService);
   public readonly route = inject(ActivatedRoute);
+
+  ngOnInit() {
+    sessionStorage.removeItem('auth.loginInProgress');
+  }
+
   async onLogin() {
     const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') || '/dashboard';
     await this.auth.login(returnUrl);

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -5,8 +5,8 @@ export const environment = {
   application: { baseUrl: 'http://localhost:4200', name: 'MergeSenseyAdmin' },
   oAuthConfig: {
     issuer: 'https://localhost:44396/',
-    redirectUri: 'http://localhost:4200/',           // с закрывающим слэшем
-    postLogoutRedirectUri: 'http://localhost:4200/', // добавь это поле
+    redirectUri: 'http://localhost:4200',            // без закрывающего слэша
+    postLogoutRedirectUri: 'http://localhost:4200',  // без закрывающего слэша
     clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',
     scope: 'offline_access openid profile MergeSensei',


### PR DESCRIPTION
## Summary
- Fix OAuth redirect URLs to drop trailing slash
- Clear lingering login flag on auth login component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1f105f90832198a28f305d67a82a