### PR TITLE
feat: add SPA client config and OpenIddict debug endpoint

### DIFF
--- a/backend/src/AICodeReview.DbMigrator/appsettings.json
+++ b/backend/src/AICodeReview.DbMigrator/appsettings.json
@@ -12,9 +12,13 @@
   },
   "OpenIddict": {
     "Applications": {
+      "MergeSenseyAdmin_Angular": {
+        "ClientId": "MergeSenseyAdmin_Angular",
+        "RootUrl": "http://localhost:4200"
+      },
       "AICodeReview_Swagger": {
         "ClientId": "AICodeReview_Swagger",
-        "RootUrl": "https://localhost:44300"
+        "RootUrl": "https://localhost:44396"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add SPA client configuration for MergeSenseyAdmin_Angular and adjust Swagger root URL
- add development endpoint to inspect OpenIddict clients redirect URIs

## Testing
- `dotnet build backend/src/AICodeReview.DbMigrator/AICodeReview.DbMigrator.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2235e26c8321b29918ee422c3152