### PR TITLE
feat(frontend): restore admin layout structure

### DIFF
--- a/frontend/admin/src/app/layout/app-layout.component.html
+++ b/frontend/admin/src/app/layout/app-layout.component.html
@@ -1,8 +1,94 @@
-<!-- Верхняя панель/навигация можешь оставить, главное — аутлеты -->
-<div class="min-h-screen bg-base-300 text-base-content">
-  <!-- основной контент -->
-  <router-outlet></router-outlet>
+<div class="min-h-screen flex bg-[#0f1114] text-gray-100">
+  <!-- Desktop sidebar -->
+  <aside class="app-sidebar hidden md:flex md:flex-col shrink-0 w-64 md:sticky md:top-0 md:h-screen border-r border-white/10 bg-black/20 backdrop-blur">
+    <div class="px-4 py-6">
+      <a routerLink="/dashboard" class="flex items-center gap-2">
+        <img ngSrc="assets/logo.png" width="32" height="32" alt="Logo" class="h-8 w-auto" />
+      </a>
+    </div>
 
-  <!-- именованный outlet для модалок -->
-  <router-outlet name="modal"></router-outlet>
+    <nav class="px-2 space-y-1">
+      @for (i of nav; track i.id) {
+        <a [routerLink]="i.to"
+           routerLinkActive="is-active"
+           [routerLinkActiveOptions]="{ exact: true }"
+           class="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+          <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            @switch (i.icon) {
+              @case ('dashboard') { <path d="M3 10l9-7 9 7v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/> }
+              @case ('projects') { <path d="M3 7V5a2 2 0 0 1 2-2h5l2 2h9v14H3Z"/> }
+              @case ('pipelines') { <path d="M22 12h-4l-3 9L9 3l-3 9H2"/> }
+              @case ('stats') { <line x1="3" y1="22" x2="21" y2="22"/><rect x="7" y="10" width="2" height="6"/><rect x="11" y="6" width="2" height="10"/><rect x="15" y="13" width="2" height="3"/> }
+              @case ('settings') { <path d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z"/> }
+              @case ('help') { <circle cx="12" cy="12" r="10"/><path d="M9 9a3 3 0 1 1 3 3v2"/><line x1="12" y1="17" x2="12" y2="17"/> }
+            }
+          </svg>
+          <span>{{ i.label }}</span>
+        </a>
+      }
+    </nav>
+
+    <div class="mt-auto px-2 pt-4 pb-6 border-t border-white/10">
+      @for (i of secondary; track i.id) {
+        <a [routerLink]="i.to"
+           routerLinkActive="is-active"
+           [routerLinkActiveOptions]="{ exact: true }"
+           class="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+          <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            @switch (i.icon) {
+              @case ('settings') { <path d="M19.4 12.9l1.4-2.4-1.8-3.1-2.8.4-1.6-2.3h-3.6L8.4 7.8l-2.8-.4-1.8 3.1 1.4 2.4-1.4 2.4 1.8 3.1 2.8-.4 1.6 2.3h3.6l1.6-2.3 2.8.4 1.8-3.1-1.4-2.4z"/> }
+              @case ('help') { <circle cx="12" cy="12" r="10"/><path d="M9 9a3 3 0 1 1 3 3v2"/><line x1="12" y1="17" x2="12" y2="17"/> }
+            }
+          </svg>
+          <span>{{ i.label }}</span>
+        </a>
+      }
+    </div>
+  </aside>
+
+  <!-- Mobile drawer -->
+  @if (sidebarOpen) {
+    <div class="md:hidden">
+      <div class="fixed inset-0 z-40 bg-black/60" (click)="toggleSidebar()"></div>
+      <aside class="fixed inset-y-0 left-0 z-50 w-64 bg-[#0f1114] border-r border-white/10 p-4 overflow-y-auto">
+        <div class="flex items-center justify-between mb-4">
+          <a routerLink="/dashboard" class="flex items-center gap-2">
+            <img ngSrc="assets/logo.png" width="32" height="32" alt="Logo" class="h-8 w-auto" />
+            <span class="text-sm font-semibold">Merge Sensei</span>
+          </a>
+          <button class="h-8 w-8 rounded-md hover:bg-white/5" (click)="toggleSidebar()" aria-label="Close">✕</button>
+        </div>
+        <nav class="space-y-1">
+          @for (i of nav; track i.id) {
+            <a [routerLink]="i.to" (click)="toggleSidebar()"
+               routerLinkActive="is-active"
+               [routerLinkActiveOptions]="{ exact: true }"
+               class="block px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+              {{ i.label }}
+            </a>
+          }
+          <div class="pt-3 mt-3 border-t border-white/10">
+            @for (i of secondary; track i.id) {
+              <a [routerLink]="i.to" (click)="toggleSidebar()"
+                 routerLinkActive="is-active"
+                 [routerLinkActiveOptions]="{ exact: true }"
+                 class="block px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-white/5 hover:text-white">
+                {{ i.label }}
+              </a>
+            }
+          </div>
+        </nav>
+      </aside>
+    </div>
+  }
+
+  <!-- Content area -->
+  <div class="flex-1 min-w-0 flex flex-col">
+    <app-header (menuToggle)="toggleSidebar()"></app-header>
+    <main class="p-4 sm:p-6">
+      <router-outlet></router-outlet>
+      <!-- Named outlet for modal dialogs -->
+      <router-outlet name="modal"></router-outlet>
+    </main>
+  </div>
 </div>

--- a/frontend/admin/src/app/layout/app-layout.component.ts
+++ b/frontend/admin/src/app/layout/app-layout.component.ts
@@ -1,10 +1,36 @@
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { AppHeaderComponent } from './header/header.component';
+
+type NavItem = {
+  id: string;
+  label: string;
+  to: string;
+  icon: 'dashboard' | 'projects' | 'pipelines' | 'stats' | 'settings' | 'help';
+};
 
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [RouterOutlet],
+  imports: [CommonModule, RouterModule, NgOptimizedImage, AppHeaderComponent],
   templateUrl: './app-layout.component.html',
+  styleUrls: ['./app-layout.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppLayoutComponent {}
+export class AppLayoutComponent {
+  public sidebarOpen = false;
+  public toggleSidebar(): void { this.sidebarOpen = !this.sidebarOpen; }
+
+  readonly nav: NavItem[] = [
+    { id: 'dashboard', label: 'Dashboard', to: '/dashboard', icon: 'dashboard' },
+    { id: 'projects',  label: 'Projects',  to: '/projects',  icon: 'projects' },
+    { id: 'pipelines', label: 'Pipelines', to: '/all-pipelines', icon: 'pipelines' },
+    { id: 'stats',     label: 'Stats',     to: '/dashboard-stats', icon: 'stats' },
+  ];
+
+  readonly secondary: NavItem[] = [
+    { id: 'settings', label: 'Settings', to: '/settings', icon: 'settings' },
+    { id: 'help',     label: 'Help',     to: '/help',     icon: 'help' },
+  ];
+}


### PR DESCRIPTION
## Summary
- reintroduce desktop sidebar, mobile drawer and header in admin layout while retaining modal router outlet
- add navigation data and sidebar toggle logic for the layout component

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2c1f1b188321b689377dc647907c