### PR TITLE
Use HTTP for local dev endpoints

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -13,6 +13,7 @@ using AICodeReview.MultiTenancy;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite.Bundling;
 using Microsoft.OpenApi.Models;
+using OpenIddict.Server;
 using OpenIddict.Validation.AspNetCore;
 using Volo.Abp;
 using Volo.Abp.Account;
@@ -50,6 +51,15 @@ public class AICodeReviewHttpApiHostModule : AbpModule
 {
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
+        var env = context.Services.GetHostingEnvironment();
+        if (env.IsDevelopment())
+        {
+            PreConfigure<OpenIddictServerBuilder>(builder =>
+            {
+                builder.DisableTransportSecurityRequirement();
+            });
+        }
+
         PreConfigure<OpenIddictBuilder>(builder =>
         {
             builder.AddValidation(options =>

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.Development.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.Development.json
@@ -3,6 +3,6 @@
     "Default": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC"
   },
   "App": {
-    "CorsOrigins": "http://localhost:4200,https://localhost:4200"
+    "CorsOrigins": "http://localhost:4200"
   }
 }

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.json
@@ -4,13 +4,13 @@
     "App": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC"
   },
   "AuthServer": {
-    "Authority": "https://localhost:44396",
+    "Authority": "http://localhost:44396",
     "SwaggerClientId": "AICodeReview_Swagger"
   },
   "App": {
-    "SelfUrl": "https://localhost:44396",
+    "SelfUrl": "http://localhost:44396",
     "ClientUrl": "http://localhost:4200",
-    "CorsOrigins": "http://localhost:4200,https://localhost:4200"
+    "CorsOrigins": "http://localhost:4200"
   },
   "StringEncryption": {
     "DefaultPassPhrase": "AICodeReviewDefaultPassPhrase"
@@ -23,7 +23,7 @@
       },
       "AICodeReview_Swagger": {
         "ClientId": "AICodeReview_Swagger",
-        "RootUrl": "https://localhost:44396"
+        "RootUrl": "http://localhost:44396"
       }
     }
   },

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -4,9 +4,9 @@ export const environment = {
   production: false,
   application: { baseUrl: 'http://localhost:4200', name: 'MergeSenseyAdmin' },
   oAuthConfig: {
-    issuer: 'https://localhost:44396/',
-    loginUrl: 'https://localhost:44396/connect/authorize',   // fallback для authorize
-    tokenEndpoint: 'https://localhost:44396/connect/token',  // fallback для token
+    issuer: 'http://localhost:44396/',
+    loginUrl: 'http://localhost:44396/connect/authorize',   // fallback для authorize
+    tokenEndpoint: 'http://localhost:44396/connect/token',  // fallback для token
     redirectUri: 'http://localhost:4200',                    // или со слэшем, но 1-в-1 как в БД
     postLogoutRedirectUri: 'http://localhost:4200',
     clientId: 'MergeSenseyAdmin_Angular',
@@ -18,8 +18,8 @@ export const environment = {
     sessionChecksEnabled: false,
   },
   apis: {
-    default: { url: 'https://localhost:44396' },
-    Default: { url: 'https://localhost:44396' },
+    default: { url: 'http://localhost:44396' },
+    Default: { url: 'http://localhost:44396' },
   },
 } as Environment;
 


### PR DESCRIPTION
## Summary
- switch Angular dev environment to HTTP-only backend URLs
- align host appsettings with HTTP scheme and permit HTTP OpenIddict traffic

## Testing
- `npm test`
- `dotnet run --project backend/src/AICodeReview.HttpApi.Host` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bf2e1b21188321b7fe377922ed7e38