### PR TITLE
fix openiddict aspnetcore usage in dev

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -14,6 +14,7 @@ using Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite.Bundling;
 using Microsoft.OpenApi.Models;
 using OpenIddict.Server;
+using OpenIddict.Server.AspNetCore; // требуется для DisableTransportSecurityRequirement()
 using OpenIddict.Validation.AspNetCore;
 using Volo.Abp;
 using Volo.Abp.Account;
@@ -52,13 +53,20 @@ public class AICodeReviewHttpApiHostModule : AbpModule
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
         var env = context.Services.GetHostingEnvironment();
-        if (env.IsDevelopment())
+
+        PreConfigure<OpenIddictServerBuilder>(builder =>
         {
-            PreConfigure<OpenIddictServerBuilder>(builder =>
+            var aspNetCoreBuilder = builder.UseAspNetCore()
+                .EnableAuthorizationEndpointPassthrough()
+                .EnableTokenEndpointPassthrough()
+                .EnableLogoutEndpointPassthrough()
+                .EnableUserinfoEndpointPassthrough();
+
+            if (env.IsDevelopment())
             {
-                builder.DisableTransportSecurityRequirement();
-            });
-        }
+                aspNetCoreBuilder.DisableTransportSecurityRequirement();
+            }
+        });
 
         PreConfigure<OpenIddictBuilder>(builder =>
         {

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -27,7 +27,7 @@ bootstrapApplication(AppComponent, {
 
     provideOAuthClient({
       resourceServer: {
-        allowedUrls: ['https://localhost:44396', 'http://localhost:44396'],
+        allowedUrls: ['http://localhost:44396'],
         sendAccessToken: true,
       },
     }),


### PR DESCRIPTION
## Summary
- integrate OpenIddict with ASP.NET Core and disable HTTPS requirement only in development
- streamline frontend OAuth client configuration

## Testing
- `dotnet build backend/AICodeReview.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf2fda002c8321982c714bc501b55c