### PR TITLE
refactor: fix OpenIddict HTTP dev config

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -14,6 +14,7 @@ using Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite;
 using Volo.Abp.AspNetCore.Mvc.UI.Theme.LeptonXLite.Bundling;
 using Microsoft.OpenApi.Models;
 using OpenIddict.Server;
+using OpenIddict.Server.AspNetCore;
 using OpenIddict.Validation.AspNetCore;
 using Volo.Abp;
 using Volo.Abp.Account;
@@ -51,15 +52,6 @@ public class AICodeReviewHttpApiHostModule : AbpModule
 {
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
-        var env = context.Services.GetHostingEnvironment();
-        if (env.IsDevelopment())
-        {
-            PreConfigure<OpenIddictServerBuilder>(builder =>
-            {
-                builder.DisableTransportSecurityRequirement();
-            });
-        }
-
         PreConfigure<OpenIddictBuilder>(builder =>
         {
             builder.AddValidation(options =>
@@ -84,6 +76,22 @@ public class AICodeReviewHttpApiHostModule : AbpModule
         {
             Configure<AbpBackgroundJobOptions>(o => o.IsJobExecutionEnabled = false);
         }
+
+        context.Services.AddOpenIddict()
+            .AddServer(options =>
+            {
+                options.UseAspNetCore()
+                    .EnableAuthorizationEndpointPassthrough()
+                    .EnableTokenEndpointPassthrough()
+                    .EnableLogoutEndpointPassthrough()
+                    .EnableUserinfoEndpointPassthrough();
+
+                if (hostingEnvironment.IsDevelopment())
+                {
+                    options.UseAspNetCore()
+                           .DisableTransportSecurityRequirement();
+                }
+            });
 
         ConfigureAuthentication(context);
         ConfigureBundles();

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -5,9 +5,9 @@ export const environment = {
   application: { baseUrl: 'http://localhost:4200', name: 'MergeSenseyAdmin' },
   oAuthConfig: {
     issuer: 'http://localhost:44396/',
-    loginUrl: 'http://localhost:44396/connect/authorize',   // fallback для authorize
-    tokenEndpoint: 'http://localhost:44396/connect/token',  // fallback для token
-    redirectUri: 'http://localhost:4200',                    // или со слэшем, но 1-в-1 как в БД
+    loginUrl: 'http://localhost:44396/connect/authorize',
+    tokenEndpoint: 'http://localhost:44396/connect/token',
+    redirectUri: 'http://localhost:4200',          // 1-в-1 как в БД OpenIddict
     postLogoutRedirectUri: 'http://localhost:4200',
     clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -27,7 +27,7 @@ bootstrapApplication(AppComponent, {
 
     provideOAuthClient({
       resourceServer: {
-        allowedUrls: ['https://localhost:44396', 'http://localhost:44396'],
+        allowedUrls: ['http://localhost:44396'],
         sendAccessToken: true,
       },
     }),


### PR DESCRIPTION
## Summary
- integrate OpenIddict ASP.NET Core builder and disable transport security only for Development
- align OAuth configuration with HTTP localhost URLs

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf2fda002c8321982c714bc501b55c