### PR TITLE
Use HTTP for local backend development

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -202,6 +202,12 @@ public class AICodeReviewHttpApiHostModule : AbpModule
         var app = context.GetApplicationBuilder();
         var env = context.GetEnvironment();
 
+        if (!env.IsDevelopment())
+        {
+            app.UseHttpsRedirection();
+            app.UseHsts();
+        }
+
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();

--- a/backend/src/AICodeReview.HttpApi.Host/Properties/launchSettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/Properties/launchSettings.json
@@ -1,24 +1,10 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "https://localhost:44396",
-      "sslPort": 44396
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "AICodeReview.HttpApi.Host": {
       "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:44396",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:44396",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "Kestrel": {
+    "Endpoints": {
+      "Http": { "Url": "http://localhost:44396" }
+    }
+  },
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC",
     "App": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC"
@@ -10,7 +15,8 @@
   "App": {
     "SelfUrl": "http://localhost:44396",
     "ClientUrl": "http://localhost:4200",
-    "CorsOrigins": "http://localhost:4200"
+    "CorsOrigins": "http://localhost:4200",
+    "RedirectAllowedUrls": "http://localhost:4200"
   },
   "StringEncryption": {
     "DefaultPassPhrase": "AICodeReviewDefaultPassPhrase"


### PR DESCRIPTION
## Summary
- Configure host profile to run on http://localhost:44396
- Add Kestrel HTTP endpoint and http URLs in settings
- Only enable HTTPS redirect outside Development environment

## Testing
- `dotnet build backend/AICodeReview.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf327368f483219b7a9c5007e04412