### PR TITLE
Remove unsupported OpenIddict logout passthrough

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -83,7 +83,6 @@ public class AICodeReviewHttpApiHostModule : AbpModule
                 options.UseAspNetCore()
                     .EnableAuthorizationEndpointPassthrough()
                     .EnableTokenEndpointPassthrough()
-                    .EnableLogoutEndpointPassthrough()
                     .EnableUserinfoEndpointPassthrough();
 
                 if (hostingEnvironment.IsDevelopment())


### PR DESCRIPTION
## Summary
- remove `EnableLogoutEndpointPassthrough` call so project builds with current OpenIddict version

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf346f7d7c83219c3501d1fb814186