### PR TITLE
refactor: preconfigure openiddict for dev

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -52,6 +52,18 @@ public class AICodeReviewHttpApiHostModule : AbpModule
 {
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
+        var env = context.Services.GetHostingEnvironment();
+
+        // Разрешаем HTTP (убираем требование HTTPS) именно в Dev
+        PreConfigure<OpenIddictServerAspNetCoreBuilder>(builder =>
+        {
+            if (env.IsDevelopment())
+            {
+                builder.DisableTransportSecurityRequirement();
+            }
+        });
+
+        // Валидация токенов — оставляем как было
         PreConfigure<OpenIddictBuilder>(builder =>
         {
             builder.AddValidation(options =>
@@ -76,21 +88,6 @@ public class AICodeReviewHttpApiHostModule : AbpModule
         {
             Configure<AbpBackgroundJobOptions>(o => o.IsJobExecutionEnabled = false);
         }
-
-        context.Services.AddOpenIddict()
-            .AddServer(options =>
-            {
-                options.UseAspNetCore()
-                    .EnableAuthorizationEndpointPassthrough()
-                    .EnableTokenEndpointPassthrough()
-                    .EnableUserinfoEndpointPassthrough();
-
-                if (hostingEnvironment.IsDevelopment())
-                {
-                    options.UseAspNetCore()
-                           .DisableTransportSecurityRequirement();
-                }
-            });
 
         ConfigureAuthentication(context);
         ConfigureBundles();


### PR DESCRIPTION
## Summary
- allow HTTP in development by disabling transport security requirement
- remove custom OpenIddict server setup

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden [IP: 172.30.1.211 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68bf3a01237c8321bf131c4c0c1edaaf