### PR TITLE
feat: enable https locally

### DIFF
--- a/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
+++ b/backend/src/AICodeReview.HttpApi.Host/AICodeReviewHttpApiHostModule.cs
@@ -52,18 +52,6 @@ public class AICodeReviewHttpApiHostModule : AbpModule
 {
     public override void PreConfigureServices(ServiceConfigurationContext context)
     {
-        var env = context.Services.GetHostingEnvironment();
-
-        // Разрешаем HTTP (убираем требование HTTPS) именно в Dev
-        PreConfigure<OpenIddictServerAspNetCoreBuilder>(builder =>
-        {
-            if (env.IsDevelopment())
-            {
-                builder.DisableTransportSecurityRequirement();
-            }
-        });
-
-        // Валидация токенов — оставляем как было
         PreConfigure<OpenIddictBuilder>(builder =>
         {
             builder.AddValidation(options =>
@@ -198,9 +186,9 @@ public class AICodeReviewHttpApiHostModule : AbpModule
         var app = context.GetApplicationBuilder();
         var env = context.GetEnvironment();
 
+        app.UseHttpsRedirection();
         if (!env.IsDevelopment())
         {
-            app.UseHttpsRedirection();
             app.UseHsts();
         }
 

--- a/backend/src/AICodeReview.HttpApi.Host/Properties/launchSettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:44396",
+      "applicationUrl": "https://localhost:44396;http://localhost:44396",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.json
@@ -1,19 +1,14 @@
 {
-  "Kestrel": {
-    "Endpoints": {
-      "Http": { "Url": "http://localhost:44396" }
-    }
-  },
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC",
     "App": "Host=localhost;Port=5432;Database=AICodeReview;Username=postgres;Password=password;Timezone=UTC"
   },
   "AuthServer": {
-    "Authority": "http://localhost:44396",
+    "Authority": "https://localhost:44396",
     "SwaggerClientId": "AICodeReview_Swagger"
   },
   "App": {
-    "SelfUrl": "http://localhost:44396",
+    "SelfUrl": "https://localhost:44396",
     "ClientUrl": "http://localhost:4200",
     "CorsOrigins": "http://localhost:4200",
     "RedirectAllowedUrls": "http://localhost:4200"
@@ -29,7 +24,7 @@
       },
       "AICodeReview_Swagger": {
         "ClientId": "AICodeReview_Swagger",
-        "RootUrl": "http://localhost:44396"
+        "RootUrl": "https://localhost:44396"
       }
     }
   },

--- a/frontend/admin/src/environments/environment.ts
+++ b/frontend/admin/src/environments/environment.ts
@@ -4,22 +4,21 @@ export const environment = {
   production: false,
   application: { baseUrl: 'http://localhost:4200', name: 'MergeSenseyAdmin' },
   oAuthConfig: {
-    issuer: 'http://localhost:44396/',
-    loginUrl: 'http://localhost:44396/connect/authorize',
-    tokenEndpoint: 'http://localhost:44396/connect/token',
-    redirectUri: 'http://localhost:4200',          // 1-в-1 как в БД OpenIddict
+    issuer: 'https://localhost:44396/',
+    loginUrl: 'https://localhost:44396/connect/authorize',
+    tokenEndpoint: 'https://localhost:44396/connect/token',
+    redirectUri: 'http://localhost:4200',
     postLogoutRedirectUri: 'http://localhost:4200',
     clientId: 'MergeSenseyAdmin_Angular',
     responseType: 'code',
     scope: 'offline_access openid profile MergeSensei',
-    requireHttps: false,
+    requireHttps: true,
     strictDiscoveryDocumentValidation: false,
     showDebugInformation: true,
     sessionChecksEnabled: false,
   },
   apis: {
-    default: { url: 'http://localhost:44396' },
-    Default: { url: 'http://localhost:44396' },
+    default: { url: 'https://localhost:44396' },
+    Default: { url: 'https://localhost:44396' },
   },
 } as Environment;
-

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -27,7 +27,7 @@ bootstrapApplication(AppComponent, {
 
     provideOAuthClient({
       resourceServer: {
-        allowedUrls: ['http://localhost:44396'],
+        allowedUrls: ['https://localhost:44396'],
         sendAccessToken: true,
       },
     }),


### PR DESCRIPTION
## Summary
- configure Angular admin for HTTPS OIDC and API calls
- enforce HTTPS redirection and drop transport security disablement
- update backend settings for HTTPS and launch profile

## Testing
- `dotnet dev-certs https --trust` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `dotnet build backend/AICodeReview.sln` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf3ea180ec83218267b8a62337ed59