### PR TITLE
Fix auth flow and routing guard

### DIFF
--- a/frontend/admin/src/app/app.routes.ts
+++ b/frontend/admin/src/app/app.routes.ts
@@ -1,30 +1,71 @@
 import { Routes } from '@angular/router';
-import { authGuard } from './auth/auth.guard';
+import { authGuard, authGuardActivate } from './auth/auth.guard';
+import { AppLayoutComponent } from './layout/app-layout.component';
+import { AuthLoginComponent } from './auth/auth-login.component';
 
 export const routes: Routes = [
-  { path: 'auth/login', loadComponent: () => import('./auth/auth-login.component').then(m => m.AuthLoginComponent) },
-  { path: 'auth/forbidden', loadComponent: () => import('./auth/auth-forbidden.component').then(m => m.AuthForbiddenComponent) },
-  { path: 'auth/loggedout', loadComponent: () => import('./auth/auth-loggedout.component').then(m => m.AuthLoggedOutComponent) },
-
   {
     path: '',
+    component: AppLayoutComponent,
+    canActivate: [authGuardActivate],
     canActivateChild: [authGuard],
-    loadComponent: () => import('./layout/app-layout.component').then(m => m.AppLayoutComponent),
     children: [
-      { path: 'dashboard', loadComponent: () => import('./pages/dashboard/dashboard.component').then(m => m.DashboardComponent) },
-      { path: 'dashboard-stats', loadComponent: () => import('./pages/dashboard-stats/dashboard-stats.component').then(m => m.DashboardStatsComponent) },
-      { path: 'projects', loadComponent: () => import('./pages/projects/projects.component').then(m => m.ProjectsComponent) },
-      { path: 'projects/new', loadComponent: () => import('./pages/create-project/create-project.component').then(m => m.CreateProjectComponent) },
-      { path: 'projects/:projectId/pipelines/new', outlet: 'modal', loadComponent: () => import('./pages/pipeline-create-modal/pipeline-create-modal.component').then(m => m.PipelineCreateModalComponent) },
-      { path: 'projects/:id', loadComponent: () => import('./pages/project-detail/project-detail.component').then(m => m.ProjectDetailComponent) },
-      { path: 'all-pipelines', loadComponent: () => import('./pages/all-pipelines/all-pipelines.component').then(m => m.AllPipelinesComponent) },
-      { path: 'pipelines/:id', loadComponent: () => import('./pages/pipeline-detail/pipeline-detail.component').then(m => m.PipelineDetailComponent) },
-      { path: 'settings', loadComponent: () => import('./pages/settings/settings.component').then(m => m.SettingsComponent) },
-      { path: 'help', loadComponent: () => import('./pages/help/help.component').then(m => m.HelpComponent) },
+      {
+        path: 'dashboard',
+        loadComponent: () => import('./pages/dashboard/dashboard.component').then(m => m.DashboardComponent),
+      },
+      {
+        path: 'dashboard-stats',
+        loadComponent: () => import('./pages/dashboard-stats/dashboard-stats.component').then(m => m.DashboardStatsComponent),
+      },
+      {
+        path: 'projects',
+        loadComponent: () => import('./pages/projects/projects.component').then(m => m.ProjectsComponent),
+      },
+      {
+        path: 'projects/new',
+        loadComponent: () => import('./pages/create-project/create-project.component').then(m => m.CreateProjectComponent),
+      },
+      {
+        path: 'projects/:projectId/pipelines/new',
+        outlet: 'modal',
+        loadComponent: () =>
+          import('./pages/pipeline-create-modal/pipeline-create-modal.component').then(
+            m => m.PipelineCreateModalComponent,
+          ),
+      },
+      {
+        path: 'projects/:id',
+        loadComponent: () => import('./pages/project-detail/project-detail.component').then(m => m.ProjectDetailComponent),
+      },
+      {
+        path: 'all-pipelines',
+        loadComponent: () => import('./pages/all-pipelines/all-pipelines.component').then(m => m.AllPipelinesComponent),
+      },
+      {
+        path: 'pipelines/:id',
+        loadComponent: () => import('./pages/pipeline-detail/pipeline-detail.component').then(m => m.PipelineDetailComponent),
+      },
+      {
+        path: 'settings',
+        loadComponent: () => import('./pages/settings/settings.component').then(m => m.SettingsComponent),
+      },
+      {
+        path: 'help',
+        loadComponent: () => import('./pages/help/help.component').then(m => m.HelpComponent),
+      },
       { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
     ],
   },
-
-  { path: '**', redirectTo: '' },
+  { path: 'auth/login', component: AuthLoginComponent },
+  {
+    path: 'auth/forbidden',
+    loadComponent: () => import('./auth/auth-forbidden.component').then(m => m.AuthForbiddenComponent),
+  },
+  {
+    path: 'auth/loggedout',
+    loadComponent: () => import('./auth/auth-loggedout.component').then(m => m.AuthLoggedOutComponent),
+  },
+  { path: '**', redirectTo: 'dashboard' },
 ];
 

--- a/frontend/admin/src/app/auth/auth.guard.ts
+++ b/frontend/admin/src/app/auth/auth.guard.ts
@@ -7,6 +7,12 @@ async function handle(stateUrl: string): Promise<boolean> {
   const router = inject(Router);
   const url = new URL(window.location.href);
 
+  // Уже авторизованы и пытаемся открыть страницу логина — ведём в дашборд.
+  if (oauth.hasValidAccessToken() && stateUrl.startsWith('/auth/login')) {
+    await router.navigateByUrl('/dashboard', { replaceUrl: true });
+    return false;
+  }
+
   console.log('[auth] stateUrl=', stateUrl);
 
   if (url.searchParams.has('error')) {
@@ -71,6 +77,11 @@ async function handle(stateUrl: string): Promise<boolean> {
 
   console.log('[auth] hasValidAccessToken=', oauth.hasValidAccessToken());
   if (oauth.hasValidAccessToken()) {
+    return true;
+  }
+
+  // На странице логина не стартуем Code Flow — просто отрисовываем компонент.
+  if (stateUrl.startsWith('/auth/login')) {
     return true;
   }
 

--- a/frontend/admin/src/app/layout/app-layout.component.html
+++ b/frontend/admin/src/app/layout/app-layout.component.html
@@ -3,7 +3,7 @@
   <aside class="app-sidebar hidden md:flex md:flex-col shrink-0 w-64 md:sticky md:top-0 md:h-screen border-r border-white/10 bg-black/20 backdrop-blur">
     <div class="px-4 py-6">
       <a routerLink="/dashboard" class="flex items-center gap-2">
-        <img ngSrc="assets/logo.png" width="32" height="32" alt="Logo" class="h-8 w-auto" />
+        <img ngSrc="assets/logo.png" width="98" height="20" alt="Logo" class="h-8 w-auto" />
       </a>
     </div>
 
@@ -53,7 +53,7 @@
       <aside class="fixed inset-y-0 left-0 z-50 w-64 bg-[#0f1114] border-r border-white/10 p-4 overflow-y-auto">
         <div class="flex items-center justify-between mb-4">
           <a routerLink="/dashboard" class="flex items-center gap-2">
-            <img ngSrc="assets/logo.png" width="32" height="32" alt="Logo" class="h-8 w-auto" />
+            <img ngSrc="assets/logo.png" width="98" height="20" alt="Logo" class="h-8 w-auto" />
             <span class="text-sm font-semibold">Merge Sensei</span>
           </a>
           <button class="h-8 w-8 rounded-md hover:bg-white/5" (click)="toggleSidebar()" aria-label="Close">✕</button>


### PR DESCRIPTION
## Summary
- guard main routes and login page to stop unnecessary redirects
- skip OIDC code flow on login and redirect authorized users to dashboard
- fix logo aspect ratio for NgOptimizedImage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf429576a48321a1048a31ae2790ba