### PR TITLE
fix: update OpenIddict seed and config

### DIFF
--- a/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/backend/src/AICodeReview.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using Volo.Abp.Data;
 using Volo.Abp.DependencyInjection;
@@ -30,11 +28,9 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
 
     private async Task CreateOrUpdateScopesAsync()
     {
-        await CreateOrUpdateScopeAsync(
-            name: "AICodeReview",
-            displayName: "AICodeReview API"
-        );
+        await CreateOrUpdateScopeAsync("AICodeReview", "AICodeReview API");
 
+        // системные OIDC-скоупы
         await CreateOrUpdateScopeAsync("openid", "OpenID Connect");
         await CreateOrUpdateScopeAsync("profile", "User profile");
         await CreateOrUpdateScopeAsync("offline_access", "Offline access");
@@ -43,30 +39,36 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
     private async Task CreateOrUpdateScopeAsync(string name, string displayName)
     {
         var existing = await _scopeManager.FindByNameAsync(name);
-        if (existing == null)
+        if (existing is null)
         {
             var desc = new OpenIddictScopeDescriptor
             {
                 Name = name,
-                DisplayName = displayName,
+                DisplayName = displayName
             };
             await _scopeManager.CreateAsync(desc);
         }
         else
         {
+            // В ЭТОЙ ВЕРСИИ OpenIddict при UpdateAsync имя ОБЯЗАТЕЛЬНО
             var desc = new OpenIddictScopeDescriptor
             {
+                Name = name,
                 DisplayName = displayName
             };
             await _scopeManager.UpdateAsync(existing, desc);
         }
     }
 
+    private static string Scope(string name) =>
+        OpenIddictConstants.Permissions.Prefixes.Scope + name;
+
     private async Task CreateOrUpdateSpaClientAsync()
     {
         const string clientId = "MergeSenseyAdmin_Angular";
 
         var existing = await _appManager.FindByClientIdAsync(clientId);
+
         var redirectUris = new[]
         {
             "http://localhost:4200"
@@ -76,33 +78,31 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
             "http://localhost:4200"
         };
 
+        // Минимальный набор для Authorization Code + PKCE
         var permissions = new HashSet<string>
         {
+            // endpoints
             OpenIddictConstants.Permissions.Endpoints.Authorization,
-            OpenIddictConstants.Permissions.Endpoints.Logout,
             OpenIddictConstants.Permissions.Endpoints.Token,
 
+            // grant/response
             OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode,
             OpenIddictConstants.Permissions.ResponseTypes.Code,
 
-            OpenIddictConstants.Permissions.Scopes.OpenId,
-            OpenIddictConstants.Permissions.Scopes.Profile,
-            OpenIddictConstants.Permissions.Scopes.OfflineAccess,
-            OpenIddictConstants.Permissions.Prefixes.Scope + "AICodeReview"
+            // scopes (через префикс, кросс-версионно)
+            Scope("openid"),
+            Scope("profile"),
+            Scope("offline_access"),
+            Scope("AICodeReview")
         };
 
-        if (existing == null)
+        if (existing is null)
         {
             var descriptor = new OpenIddictApplicationDescriptor
             {
                 ClientId = clientId,
                 DisplayName = "MergeSensey Admin SPA",
-                Type = OpenIddictConstants.ClientTypes.Public,
-                ConsentType = OpenIddictConstants.ConsentTypes.Systematic,
-                Requirements =
-                {
-                    OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange
-                }
+                ConsentType = OpenIddictConstants.ConsentTypes.Systematic // без экрана согласия
             };
 
             foreach (var uri in redirectUris)
@@ -114,6 +114,9 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
             foreach (var p in permissions)
                 descriptor.Permissions.Add(p);
 
+            // PKCE – публичный SPA без client secret
+            descriptor.Requirements.Add(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange);
+
             await _appManager.CreateAsync(descriptor);
         }
         else
@@ -121,14 +124,15 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
             var descriptor = new OpenIddictApplicationDescriptor
             {
                 DisplayName = "MergeSensey Admin SPA",
-                Type = OpenIddictConstants.ClientTypes.Public,
                 ConsentType = OpenIddictConstants.ConsentTypes.Systematic
             };
 
             foreach (var uri in redirectUris)
                 descriptor.RedirectUris.Add(new Uri(uri));
+
             foreach (var uri in postLogoutRedirectUris)
                 descriptor.PostLogoutRedirectUris.Add(new Uri(uri));
+
             foreach (var p in permissions)
                 descriptor.Permissions.Add(p);
 
@@ -138,3 +142,4 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
         }
     }
 }
+

--- a/backend/src/AICodeReview.HttpApi.Host/appsettings.json
+++ b/backend/src/AICodeReview.HttpApi.Host/appsettings.json
@@ -2,12 +2,13 @@
   "App": {
     "SelfUrl": "https://localhost:44396",
     "ClientUrl": "http://localhost:4200",
-    "CorsOrigins": "http://localhost:4200"
+    "CorsOrigins": "http://localhost:4200",
+    "RedirectAllowedUrls": "http://localhost:4200"
   },
   "AuthServer": {
     "Authority": "https://localhost:44396/",
-    "RequireHttpsMetadata": "true",
-    "SwaggerClientId": "MergeSenseyAdmin_Angular"
+    "RequireHttpsMetadata": true,
+    "SwaggerClientId": "AICodeReview_Swagger"
   },
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=aicodereview;User ID=postgres;Password=postgres"


### PR DESCRIPTION
## Summary
- replace OpenIddict data seeding to register scopes and SPA client with PKCE
- align app settings for localhost auth server

## Testing
- `npm start` *(fails: dotnet not installed; `apt-get update` 403; angular build succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe9a178fc832182ffab7660dd5516